### PR TITLE
source-os: add MIT license and expand README

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 SociOS-Linux
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,65 @@
-# source-os
-This is the main SociOS Linux SourceOS Repo.
+# SourceOS (SociOS-Linux)
+
+This repository is the **main SourceOS implementation hub** in the `SociOS-Linux` org.
+
+It is intentionally **implementation-facing**.
+
+- **Design/RFCs** live in `SociOS-Linux/enhancements` (CoreOS/Silverblue-style enhancement process).
+- **Typed contracts** live in `SourceOS-Linux/sourceos-spec` (canonical schema + OpenAPI/AsyncAPI).
+
+This repo implements the **workstation profile** and the **bootstrap tooling** that turns the design into a usable system.
+
+## Current focus: Workstation Profile v0
+
+Workstation Profile v0 is a reproducible, CLI-first workstation for GNOME/CoreOS/Silverblue-derived systems.
+
+It standardizes:
+
+- A modern terminal toolchain (fzf/atuin/bat/zoxide/yazi/eza/gum/direnv/etc.) as a manifest.
+- A layered install strategy compatible with immutable hosts:
+  - SYSTEM (rpm-ostree minimal)
+  - USER (Linuxbrew/Homebrew + per-repo toolchains)
+  - TOOLBOX (isolated builds / AUR bridge)
+- A launcher action surface (Albert) for “actions-first” invocation.
+
+See `workstation/` for implementation.
+
+## Repo layout
+
+```
+source-os/
+  workstation/
+    profiles/
+      workstation-v0/
+        manifest.yaml
+        install.sh
+        doctor.sh
+        config/
+          shell/
+          tmux/
+          albert/
+          gnome/
+```
+
+## Usage (local)
+
+### Apply workstation profile
+
+```bash
+./workstation/profiles/workstation-v0/install.sh
+```
+
+### Verify profile
+
+```bash
+./workstation/profiles/workstation-v0/doctor.sh
+```
+
+## Safety/Trust
+
+- This repo provides **installers** and **configuration**, not a second execution authority.
+- Agentic actions surfaced by launcher/CLI must map cleanly onto the canonical execution/audit plane.
+
+Related:
+- Enhancement PR: `SociOS-Linux/enhancements` (Workstation Profile v0)
+- ADR PR: `SourceOS-Linux/sourceos-spec` (Workstation/execution boundary)


### PR DESCRIPTION
This commit expands the README to include details about SourceOS, while also adding the MIT license. This enhances transparency, ensuring legal clarity and operational coverage in a unified source for SourceOS configuration.