### PR TITLE
workstation: add profile v0 scaffold + CLI + install/doctor

### DIFF
--- a/workstation/README.md
+++ b/workstation/README.md
@@ -1,0 +1,21 @@
+# Workstation profiles
+
+This directory contains **implementation artifacts** for SourceOS workstation profiles.
+
+A workstation profile is a versioned bundle of:
+
+- Package manifests (SYSTEM vs USER vs TOOLBOX layers)
+- Shell/terminal defaults (keyboard-first)
+- Desktop defaults (GNOME) where applicable
+- Launcher actions (Albert) where applicable
+- Validation probes (`doctor`)
+
+Profiles are stored under:
+
+- `workstation/profiles/<profile-name>/`
+
+The CLI entrypoint is:
+
+- `workstation/bin/sourceos`
+
+Design/RFC source of truth lives in `SociOS-Linux/enhancements`, while typed contract boundaries live in `SourceOS-Linux/sourceos-spec`.

--- a/workstation/bin/sourceos
+++ b/workstation/bin/sourceos
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# SourceOS workstation CLI (v0)
+# NOTE: This is intentionally dependency-light (bash + coreutils).
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PROFILES_DIR="$ROOT_DIR/profiles"
+
+usage() {
+  cat <<'EOF'
+sourceos - SourceOS workstation helper
+
+Usage:
+  sourceos profile list
+  sourceos profile apply <profile>
+  sourceos doctor [<profile>]
+
+Notes:
+  - This CLI is the implementation surface. Design/RFCs live in SociOS-Linux/enhancements.
+  - Typed contract boundaries live in SourceOS-Linux/sourceos-spec.
+EOF
+}
+
+err() { printf "ERROR: %s\n" "$*" >&2; }
+info() { printf "INFO: %s\n" "$*" >&2; }
+
+profile_list() {
+  if [[ ! -d "$PROFILES_DIR" ]]; then
+    err "profiles directory not found: $PROFILES_DIR"
+    exit 2
+  fi
+  (cd "$PROFILES_DIR" && ls -1)
+}
+
+profile_apply() {
+  local profile=${1:-}
+  [[ -n "$profile" ]] || { err "profile name required"; usage; exit 2; }
+  local dir="$PROFILES_DIR/$profile"
+  local installer="$dir/install.sh"
+  [[ -x "$installer" ]] || { err "installer not found or not executable: $installer"; exit 2; }
+  exec "$installer"
+}
+
+doctor() {
+  local profile=${1:-workstation-v0}
+  local dir="$PROFILES_DIR/$profile"
+  local doc="$dir/doctor.sh"
+  [[ -x "$doc" ]] || { err "doctor not found or not executable: $doc"; exit 2; }
+  exec "$doc"
+}
+
+main() {
+  local cmd=${1:-}
+  case "$cmd" in
+    -h|--help|help|"")
+      usage
+      ;;
+    profile)
+      shift
+      local sub=${1:-}
+      case "$sub" in
+        list)
+          profile_list
+          ;;
+        apply)
+          shift
+          profile_apply "${1:-}"
+          ;;
+        *)
+          err "unknown profile subcommand: $sub"
+          usage
+          exit 2
+          ;;
+      esac
+      ;;
+    doctor)
+      shift
+      doctor "${1:-workstation-v0}"
+      ;;
+    *)
+      err "unknown command: $cmd"
+      usage
+      exit 2
+      ;;
+  esac
+}
+
+main "$@"

--- a/workstation/profiles/workstation-v0/doctor.sh
+++ b/workstation/profiles/workstation-v0/doctor.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROFILE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MANIFEST="$PROFILE_DIR/manifest.yaml"
+
+fail=0
+
+info() { printf "INFO: %s\n" "$*" >&2; }
+warn() { printf "WARN: %s\n" "$*" >&2; }
+err()  { printf "ERROR: %s\n" "$*" >&2; }
+
+have() { command -v "$1" >/dev/null 2>&1; }
+
+check() {
+  local bin=$1
+  if have "$bin"; then
+    info "ok: $bin"
+  else
+    err "missing: $bin"
+    fail=1
+  fi
+}
+
+os_id() {
+  if [[ "$(uname -s)" == "Darwin" ]]; then
+    echo "macos"; return
+  fi
+  if [[ -r /etc/os-release ]]; then
+    . /etc/os-release
+    echo "${ID:-linux}"
+  else
+    echo "linux"
+  fi
+}
+
+main() {
+  info "Doctor: workstation-v0"
+  info "OS: $(os_id)"
+
+  # Baseline expectations
+  check git
+  check ssh
+
+  # System layer signals
+  if have rpm-ostree; then
+    info "rpm-ostree: present"
+  else
+    warn "rpm-ostree: not present (ok on non-ostree distros)"
+  fi
+
+  if have podman; then
+    info "ok: podman"
+  else
+    warn "missing: podman (required for toolbox-based workflows)"
+  fi
+
+  # USER tools
+  # We treat brew as the primary userland provider for parity.
+  if have brew; then
+    info "ok: brew"
+  else
+    warn "missing: brew (USER layer likely incomplete)"
+  fi
+
+  # Core CLI UX
+  check fzf
+  check atuin
+  check bat
+  check zoxide
+  check yazi
+  check eza
+  check gum
+  check direnv
+  check rg
+  check fd
+  check tmux
+
+  # Git UX
+  check gh
+  check lazygit
+  check tig
+
+  # JSON
+  check jnv
+  check gojq
+
+  # K8s
+  check k9s
+
+  # File motion
+  check rclone
+  check mc
+  check rsync
+
+  if [[ $fail -ne 0 ]]; then
+    err "doctor: FAIL"
+    exit 2
+  fi
+
+  info "doctor: OK"
+}
+
+main "$@"

--- a/workstation/profiles/workstation-v0/install.sh
+++ b/workstation/profiles/workstation-v0/install.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROFILE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MANIFEST="$PROFILE_DIR/manifest.yaml"
+
+err() { printf "ERROR: %s\n" "$*" >&2; }
+info() { printf "INFO: %s\n" "$*" >&2; }
+
+have() { command -v "$1" >/dev/null 2>&1; }
+
+os_id() {
+  if [[ "$(uname -s)" == "Darwin" ]]; then
+    echo "macos"
+    return
+  fi
+  if [[ -r /etc/os-release ]]; then
+    . /etc/os-release
+    echo "${ID:-linux}"
+  else
+    echo "linux"
+  fi
+}
+
+install_brew() {
+  # We do not auto-run remote scripts here. We require brew to be preinstalled.
+  err "Homebrew not found. Install Homebrew first, then re-run." 
+  err "macOS: https://brew.sh (inspect before running)"
+  err "Linuxbrew: https://docs.brew.sh/Homebrew-on-Linux"
+  exit 2
+}
+
+install_user_brew_packages() {
+  if ! have brew; then
+    install_brew
+  fi
+
+  info "Installing USER packages via brew (manifest-driven)."
+
+  # NOTE: minimal parser: extract lines under 'brew:' at indent 10+ and '- ' entries.
+  # This assumes the manifest format in this repo and is intentionally simple.
+  awk '
+    $0 ~ /^\s*brew:\s*$/ {in=1; next}
+    in && $0 ~ /^\s*- / {gsub(/^\s*- /, ""); print; next}
+    in && $0 ~ /^\s*[^-[:space:]]/ {exit}
+  ' "$MANIFEST" | while read -r pkg; do
+    [[ -z "$pkg" ]] && continue
+    info "brew install $pkg"
+    brew install "$pkg" || true
+  done
+}
+
+install_system_packages() {
+  local id
+  id="$(os_id)"
+
+  if have rpm-ostree; then
+    info "Detected rpm-ostree. Installing SYSTEM packages (may require reboot)."
+    # minimal set (kept in manifest): git, ssh, podman, toolbox, wl-clipboard, jq
+    sudo rpm-ostree install git openssh-clients podman toolbox wl-clipboard jq || true
+    info "If rpm-ostree applied new packages, reboot before proceeding."
+    return
+  fi
+
+  if have dnf; then
+    info "Installing SYSTEM packages via dnf."
+    sudo dnf install -y git openssh-clients podman toolbox wl-clipboard jq || true
+    return
+  fi
+
+  err "No supported system package manager detected (rpm-ostree or dnf)."
+  err "OS id: $id"
+  exit 2
+}
+
+main() {
+  if [[ ! -f "$MANIFEST" ]]; then
+    err "manifest not found: $MANIFEST"
+    exit 2
+  fi
+
+  install_system_packages
+  install_user_brew_packages
+
+  info "Workstation profile install complete (v0)."
+  info "Next: run doctor: $PROFILE_DIR/doctor.sh"
+}
+
+main "$@"

--- a/workstation/profiles/workstation-v0/manifest.yaml
+++ b/workstation/profiles/workstation-v0/manifest.yaml
@@ -1,0 +1,123 @@
+apiVersion: sourceos.workstation/v0
+kind: WorkstationProfile
+metadata:
+  name: workstation-v0
+  description: >-
+    CLI-first GNOME workstation profile for CoreOS/Silverblue-derived systems.
+    Focus: keyboard-first, modern terminal toolchain, Albert action surface.
+  compatibility:
+    os:
+      - fedora
+      - fedora-silverblue
+      - fedora-coreos
+      - rhel-coreos
+      - macos
+spec:
+  layers:
+    system:
+      description: >-
+        Minimal host dependencies. Keep this small on immutable hosts.
+      packages:
+        # NOTE: On rpm-ostree systems these are layered and may require reboot.
+        rpm_ostree:
+          - git
+          - openssh-clients
+          - podman
+          - toolbox
+          - wl-clipboard
+          - jq
+        dnf:
+          - git
+          - openssh-clients
+          - podman
+          - toolbox
+          - wl-clipboard
+          - jq
+
+    user:
+      description: >-
+        Developer toolchain and shell UX. Prefer userland package managers for parity.
+      packages:
+        brew:
+          # Navigation / shell UX
+          - fzf
+          - atuin
+          - bat
+          - zoxide
+          - yazi
+          - eza
+          - gum
+          - direnv
+          - tldr
+          - fd
+          - ripgrep
+
+          # Git
+          - lazygit
+          - gh
+          - diff-so-fancy
+          - tig
+          - svu
+
+          # Process / ops
+          - tmux
+          - mprocs
+          - lazydocker
+          - k9s
+          - btop
+
+          # JSON
+          - jnv
+          - gojq
+          - fx
+          - jless
+          - jqp
+
+          # Disk
+          - dua-cli
+          - dust
+          - kondo
+
+          # Markdown/Docs
+          - glow
+
+          # Bench
+          - hyperfine
+
+          # File motion
+          - rclone
+          - minio-mc
+          - rsync
+
+        # Optional / platform-specific tooling can be resolved by installer
+        # and may not exist on every package backend.
+
+    toolbox:
+      description: >-
+        Isolated build surface for AUR/source builds. Treated as untrusted.
+      packages:
+        arch:
+          - base-devel
+          - git
+          - yay
+
+  desktop:
+    gnome:
+      description: >-
+        GNOME customization is behavioral (extensions + GSettings) not core forks.
+      inputs:
+        kinto:
+          enabled: true
+          note: "Kinto is X11-centric; Wayland support requires validation." 
+        fusuma:
+          enabled: true
+          note: "Gestures via libinput; validate hardware compatibility." 
+
+  launcher:
+    albert:
+      description: >-
+        Albert is the action bus / command palette. Do not duplicate GNOME file indexing.
+      plugin:
+        id: sourceos
+        trigger: "sourceos "
+


### PR DESCRIPTION
STACKED ON TOP OF #1 (base branch: feat/workstation-v0-bootstrap).

Adds the minimal runnable Workstation Profile v0 implementation:

- `workstation/README.md` (profile semantics)
- `workstation/bin/sourceos` (CLI entrypoint: profile list/apply + doctor)
- `workstation/profiles/workstation-v0/manifest.yaml` (SYSTEM/USER/TOOLBOX layer manifest)
- `workstation/profiles/workstation-v0/install.sh` (SYSTEM via rpm-ostree/dnf; USER via brew)
- `workstation/profiles/workstation-v0/doctor.sh` (validation)

This is intentionally small and dependency-light so we can iterate rapidly without breaking immutable-host discipline.

Next PRs will layer in:
- Shell spine (fzf/atuin/zoxide/direnv defaults)
- Clipboard abstraction (pbcopy/wl-copy/xclip)
- Albert SourceOS plugin (action bus)
- GNOME GSettings baseline + extension pinset
- Toolbox/AUR bridge automation
