### PR TITLE
workstation: shell spine (fzf/atuin/zoxide/direnv + clipboard helpers)

### DIFF
--- a/workstation/profiles/workstation-v0/config/shell/README.md
+++ b/workstation/profiles/workstation-v0/config/shell/README.md
@@ -1,0 +1,25 @@
+# Shell spine (Workstation Profile v0)
+
+This directory contains the **keyboard-first shell UX spine** for the workstation profile.
+
+Design goals:
+
+- Predictable navigation primitives (fzf, zoxide, atuin)
+- XDG-friendly configuration (avoid scattering files)
+- Minimal invasive changes to user dotfiles (provide a single snippet to source)
+- Works in zsh, bash, and fish (where possible)
+
+## Files
+
+- `common.sh`: shared functions + env
+- `zshrc.snippet`: zsh-specific glue
+- `bashrc.snippet`: bash-specific glue
+
+## How to enable
+
+The profile installer will:
+
+1) Create `~/.config/sourceos/` and copy these files.
+2) Append a single guarded `source` line into the user’s shell rc (opt-in behavior is preferred; v0 prints instructions and does not mutate by default).
+
+Until we implement the dotfile mutator, you can enable manually by sourcing the snippet.

--- a/workstation/profiles/workstation-v0/config/shell/bashrc.snippet
+++ b/workstation/profiles/workstation-v0/config/shell/bashrc.snippet
@@ -1,0 +1,8 @@
+# SourceOS Workstation Spine (Bash)
+
+SOURCEOS_SPINE_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/sourceos/shell"
+
+if [[ -f "$SOURCEOS_SPINE_DIR/common.sh" ]]; then
+  # shellcheck source=/dev/null
+  . "$SOURCEOS_SPINE_DIR/common.sh"
+fi

--- a/workstation/profiles/workstation-v0/config/shell/common.sh
+++ b/workstation/profiles/workstation-v0/config/shell/common.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Common shell spine for SourceOS Workstation Profile v0
+# Safe to source multiple times.
+
+# Guard
+if [[ -n "${SOURCEOS_SHELL_SPINE_LOADED:-}" ]]; then
+  return 0 2>/dev/null || true
+fi
+export SOURCEOS_SHELL_SPINE_LOADED=1
+
+# --- direnv ---
+if command -v direnv >/dev/null 2>&1; then
+  if [[ -n "${ZSH_VERSION:-}" ]]; then
+    eval "$(direnv hook zsh)"
+  elif [[ -n "${BASH_VERSION:-}" ]]; then
+    eval "$(direnv hook bash)"
+  fi
+fi
+
+# --- atuin ---
+if command -v atuin >/dev/null 2>&1; then
+  if [[ -n "${ZSH_VERSION:-}" ]]; then
+    eval "$(atuin init zsh --disable-up-arrow)"
+  elif [[ -n "${BASH_VERSION:-}" ]]; then
+    eval "$(atuin init bash --disable-up-arrow)"
+  fi
+fi
+
+# --- zoxide ---
+if command -v zoxide >/dev/null 2>&1; then
+  if [[ -n "${ZSH_VERSION:-}" ]]; then
+    eval "$(zoxide init zsh)"
+  elif [[ -n "${BASH_VERSION:-}" ]]; then
+    eval "$(zoxide init bash)"
+  fi
+  # alias only if not already customized
+  alias cd='z' 2>/dev/null || true
+fi
+
+# --- fzf defaults (fd-backed) ---
+if command -v fzf >/dev/null 2>&1; then
+  if command -v fd >/dev/null 2>&1; then
+    export FZF_DEFAULT_COMMAND='fd --hidden --follow --exclude .git'
+    export FZF_CTRL_T_COMMAND="$FZF_DEFAULT_COMMAND"
+    export FZF_ALT_C_COMMAND='fd --type d --hidden --follow --exclude .git'
+  fi
+  export FZF_DEFAULT_OPTS='--height 40% --layout=reverse --border'
+fi
+
+# --- ergonomic aliases (opt-in minimalism) ---
+if command -v eza >/dev/null 2>&1; then
+  alias ls='eza --group-directories-first --icons' 2>/dev/null || true
+  alias ll='eza -lah --group-directories-first --icons' 2>/dev/null || true
+fi
+if command -v bat >/dev/null 2>&1; then
+  alias cat='bat' 2>/dev/null || true
+fi
+if command -v yazi >/dev/null 2>&1; then
+  alias y='yazi' 2>/dev/null || true
+fi
+
+# --- clipboard abstraction ---
+clipcopy() {
+  if command -v pbcopy >/dev/null 2>&1; then
+    pbcopy
+  elif command -v wl-copy >/dev/null 2>&1; then
+    wl-copy
+  elif command -v xclip >/dev/null 2>&1; then
+    xclip -selection clipboard
+  else
+    echo "No clipboard tool found (pbcopy/wl-copy/xclip)" >&2
+    return 1
+  fi
+}
+
+clippaste() {
+  if command -v pbpaste >/dev/null 2>&1; then
+    pbpaste
+  elif command -v wl-paste >/dev/null 2>&1; then
+    wl-paste
+  elif command -v xclip >/dev/null 2>&1; then
+    xclip -selection clipboard -o
+  else
+    echo "No clipboard tool found (pbpaste/wl-paste/xclip)" >&2
+    return 1
+  fi
+}

--- a/workstation/profiles/workstation-v0/config/shell/zshrc.snippet
+++ b/workstation/profiles/workstation-v0/config/shell/zshrc.snippet
@@ -1,0 +1,13 @@
+# SourceOS Workstation Spine (Zsh)
+
+# SourceOS shell spine (Zsh)
+# Safe to source multiple times.
+
+SOURCEOS_SPINE_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/sourceos/shell"
+
+if [[ -f "$SOURCEOS_SPINE_DIR/common.sh" ]]; then
+  source "$SOURCEOS_SPINE_DIR/common.sh"
+fi
+
+# Zsh-specific keybindings can be added here without affecting bash.
+# Example: bindkey '^R' atuin-search is handled by atuin init.

--- a/workstation/profiles/workstation-v0/install-shell-spine.sh
+++ b/workstation/profiles/workstation-v0/install-shell-spine.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROFILE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$PROFILE_DIR/../.." && pwd)"
+SRC_DIR="$PROFILE_DIR/config"
+DST_BASE="${XDG_CONFIG_HOME:-$HOME/.config}/sourceos"
+
+info(){ printf "INFO: %s\n" "$*" >&2; }
+err(){ printf "ERROR: %s\n" "$*\n" >&2; }
+
+copy_spine() {
+  mkdir -p "$DST_BASE/shell"
+  cp -f "$SRC_DIR/shell/common.sh" "$DST_BASE/shell/common.sh"
+  cp -f "$SRC_DIR/shell/zshrc.snippet" "$DST_BASE/shell/zshrc.snippet"
+  cp -f "$SRC_DIR/shell/bashrc.snippet" "$DST_BASE/shell/bashrc.snippet"
+  chmod 0644 "$DST_BASE/shell/"*.sh "$DST_BASE/shell/"*.snippet || true
+}
+
+print_instructions() {
+  cat <<EOF
+
+SourceOS shell spine installed to:
+  $DST_BASE/shell/
+
+Enable it by sourcing one line in your shell rc:
+
+  # Zsh: add to ~/.zshrc
+  source $DST_BASE/shell/zshrc.snippet
+
+  # Bash: add to ~/.bashrc
+  . $DST_BASE/shell/bashrc.snippet
+
+This installer does NOT auto-edit rc files in v0.
+EOF
+}
+
+main(){
+  copy_spine
+  print_instructions
+}
+
+main "$@"


### PR DESCRIPTION
STACKED ON TOP OF PR #2 (base branch: feat/workstation-v0-profile).

Adds the workstation shell spine:

- `common.sh`: shared env + init (direnv, atuin, zoxide, fzf defaults) + clipboard abstraction (`clipcopy`/`clippaste`)
- `zshrc.snippet` / `bashrc.snippet`: minimal glue to source the spine
- `install-shell-spine.sh`: copies spine to `$XDG_CONFIG_HOME/sourceos/shell` and prints one-line enable instructions (does not auto-edit rc files in v0)

This moves us toward the “don’t think about it” keyboard-first CLI experience without forcing dotfile mutation yet.

Next PR: extend `install.sh` to run `install-shell-spine.sh` and optionally offer a safe rc-file patch mode.
