### PR TITLE
build: add multi-channel Linux realization scaffold

### DIFF
--- a/channels/candidate.json
+++ b/channels/candidate.json
@@ -1,0 +1,21 @@
+{
+  "channel": "candidate",
+  "artifact_set": "example:source-os-candidate-artifact-set",
+  "source_rev": "git:feature-linux-realization-v2",
+  "flake_lock": "pending",
+  "capabilities": {
+    "image-build": "0.1.0",
+    "promotion": "0.1.0",
+    "rollback": "0.1.0"
+  },
+  "eval_bundle": "candidate-eval-pending",
+  "data_snapshots": {
+    "policies": "pending",
+    "benchmarks": "pending"
+  },
+  "promoted_at": "2026-04-15T19:40:00Z",
+  "rollback_to": "dev:example:source-os-dev-artifact-set",
+  "approved_by": [
+    "operator"
+  ]
+}

--- a/channels/stable.json
+++ b/channels/stable.json
@@ -1,0 +1,21 @@
+{
+  "channel": "stable",
+  "artifact_set": "example:source-os-stable-artifact-set",
+  "source_rev": "git:feature-linux-realization-v2",
+  "flake_lock": "pending",
+  "capabilities": {
+    "image-build": "0.1.0",
+    "promotion": "0.1.0",
+    "rollback": "0.1.0"
+  },
+  "eval_bundle": "stable-eval-pending",
+  "data_snapshots": {
+    "policies": "pending",
+    "benchmarks": "pending"
+  },
+  "promoted_at": "2026-04-15T19:45:00Z",
+  "rollback_to": "candidate:example:source-os-candidate-artifact-set",
+  "approved_by": [
+    "operator"
+  ]
+}

--- a/hosts/canary-x86_64/default.nix
+++ b/hosts/canary-x86_64/default.nix
@@ -1,0 +1,13 @@
+{ ... }:
+{
+  imports = [
+    ../../profiles/linux-candidate/default.nix
+  ];
+
+  networking.hostName = "canary-x86_64";
+
+  sourceos.build = {
+    role = "canary-x86_64";
+    channel = "candidate";
+  };
+}

--- a/hosts/stable-x86_64/default.nix
+++ b/hosts/stable-x86_64/default.nix
@@ -1,0 +1,13 @@
+{ ... }:
+{
+  imports = [
+    ../../profiles/linux-stable/default.nix
+  ];
+
+  networking.hostName = "stable-x86_64";
+
+  sourceos.build = {
+    role = "stable-x86_64";
+    channel = "stable";
+  };
+}

--- a/images/canary-x86_64.nix
+++ b/images/canary-x86_64.nix
@@ -1,0 +1,8 @@
+{ ... }:
+{
+  imports = [
+    ../hosts/canary-x86_64/default.nix
+  ];
+
+  sourceos.build.role = "canary-x86_64-image";
+}

--- a/images/release-x86_64.nix
+++ b/images/release-x86_64.nix
@@ -1,0 +1,8 @@
+{ ... }:
+{
+  imports = [
+    ../hosts/stable-x86_64/default.nix
+  ];
+
+  sourceos.build.role = "stable-x86_64-image";
+}

--- a/profiles/linux-candidate/default.nix
+++ b/profiles/linux-candidate/default.nix
@@ -1,0 +1,11 @@
+{ ... }:
+{
+  imports = [
+    ../../modules/build/default.nix
+  ];
+
+  sourceos.build = {
+    role = "linux-candidate";
+    channel = "candidate";
+  };
+}

--- a/profiles/linux-stable/default.nix
+++ b/profiles/linux-stable/default.nix
@@ -1,0 +1,11 @@
+{ ... }:
+{
+  imports = [
+    ../../modules/build/default.nix
+  ];
+
+  sourceos.build = {
+    role = "linux-stable";
+    channel = "stable";
+  };
+}


### PR DESCRIPTION
## Summary
- add candidate and stable Linux profiles alongside the existing dev realization
- add canary and stable host scaffolds
- add candidate and stable channel manifests
- add canary and release image entry points for the x86_64 side

## Why
We already established the cross-repo split:
- `SocioProphet/agentplane` owns the execution and promotion control-plane
- `SocioProphet/socioprophet-agent-standards` owns the shared channel and capability vocabulary
- `SociOS-Linux/source-os` owns Linux host/image/build realization

This PR makes the Linux side reflect the full three-channel model (`dev`, `candidate`, `stable`) instead of remaining dev-only.

## Notes
- this is still scaffold-level realization, not final host/image wiring
- `flake.nix` still needs an in-place follow-up patch to export concrete `nixosConfigurations` and checks
- branch cut from current `main` after re-checking upstream movement to avoid building on stale state
