### PR TITLE
workstation: toolbox/AUR bridge (arch toolbox + yay helper)

### DIFF
--- a/workstation/profiles/workstation-v0/toolbox/README.md
+++ b/workstation/profiles/workstation-v0/toolbox/README.md
@@ -1,0 +1,33 @@
+# Toolbox / AUR bridge
+
+Workstation Profile v0 includes an optional **AUR bridge** for immutable hosts.
+
+Rationale:
+
+- On rpm-ostree/Silverblue/CoreOS derivatives, the host should remain minimal.
+- AUR packages are often untrusted/fast-moving and should not collapse into SYSTEM trust.
+- Toolbox provides an isolated user-space container that still has good UX (access to home, etc.).
+
+This directory provides `sourceos-aur`, a small helper that:
+
+- Creates an Arch Linux toolbox container
+- Installs `base-devel` + `yay`
+- Installs requested AUR packages inside the container
+
+## Usage
+
+```bash
+workstation/profiles/workstation-v0/toolbox/sourceos-aur init
+workstation/profiles/workstation-v0/toolbox/sourceos-aur install <aur-package>
+```
+
+## Notes
+
+- Installed binaries live inside the container.
+- Host integration should wrap execution via:
+
+```bash
+toolbox run --container sourceos-arch -- <cmd>
+```
+
+This is a deliberate boundary: it keeps AUR out of the host by default.

--- a/workstation/profiles/workstation-v0/toolbox/sourceos-aur
+++ b/workstation/profiles/workstation-v0/toolbox/sourceos-aur
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# SourceOS Toolbox/AUR bridge (v0)
+# Purpose: provide a deterministic place to build/install AUR packages without contaminating the host.
+# Model: create an Arch-based toolbox container and use yay inside it.
+
+PROFILE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+err(){ printf "ERROR: %s\n" "$*" >&2; }
+info(){ printf "INFO: %s\n" "$*" >&2; }
+
+have(){ command -v "$1" >/dev/null 2>&1; }
+
+require(){
+  local bin=$1
+  have "$bin" || { err "missing required command: $bin"; exit 2; }
+}
+
+container_name(){
+  # stable name (profile scoped)
+  echo "sourceos-arch"
+}
+
+ensure_toolbox(){
+  require toolbox
+  require podman
+}
+
+ensure_arch_toolbox(){
+  ensure_toolbox
+
+  local name
+  name="$(container_name)"
+
+  # idempotent: if container exists, do nothing.
+  if toolbox list 2>/dev/null | awk '{print $1}' | grep -qx "$name"; then
+    info "toolbox exists: $name"
+    return
+  fi
+
+  info "creating toolbox container: $name"
+  # toolbox supports non-fedora images via --image
+  toolbox create --container "$name" --image archlinux:latest
+}
+
+arch_bootstrap(){
+  local name
+  name="$(container_name)"
+
+  info "bootstrapping AUR toolchain inside: $name"
+
+  toolbox run --container "$name" -- bash -lc '
+    set -euo pipefail
+    pacman -Sy --noconfirm
+    pacman -S --noconfirm --needed base-devel git sudo
+
+    # create a non-root build user
+    if ! id -u builder >/dev/null 2>&1; then
+      useradd -m -s /bin/bash builder
+      echo "builder ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/builder
+      chmod 0440 /etc/sudoers.d/builder
+    fi
+
+    # install yay if missing
+    if ! command -v yay >/dev/null 2>&1; then
+      su - builder -c "cd ~ && git clone https://aur.archlinux.org/yay.git && cd yay && makepkg -si --noconfirm"
+    fi
+  '
+}
+
+aur_install(){
+  local pkg=${1:-}
+  [[ -n "$pkg" ]] || { err "package name required"; exit 2; }
+
+  local name
+  name="$(container_name)"
+
+  ensure_arch_toolbox
+  arch_bootstrap
+
+  info "installing AUR package in toolbox ($name): $pkg"
+  toolbox run --container "$name" -- bash -lc "su - builder -c 'yay -S --noconfirm --needed $pkg'"
+
+  info "done: $pkg (installed inside toolbox container only)"
+}
+
+usage(){
+  cat <<'EOF'
+sourceos-aur - SourceOS toolbox/AUR bridge
+
+Usage:
+  sourceos-aur init
+  sourceos-aur install <aur-package>
+
+Notes:
+  - This keeps AUR builds out of the host trust boundary.
+  - Installed binaries live inside the toolbox container.
+  - For host integration, wrap calls via `toolbox run --container sourceos-arch -- <cmd>`.
+EOF
+}
+
+main(){
+  local cmd=${1:-}
+  case "$cmd" in
+    init)
+      ensure_arch_toolbox
+      arch_bootstrap
+      ;;
+    install)
+      shift
+      aur_install "${1:-}"
+      ;;
+    -h|--help|help|"")
+      usage
+      ;;
+    *)
+      err "unknown command: $cmd"
+      usage
+      exit 2
+      ;;
+  esac
+}
+
+main "$@"


### PR DESCRIPTION
STACKED ON TOP OF PR #4 (base branch: feat/workstation-v0-installer-wiring).

Adds optional AUR bridge tooling for immutable hosts:

- `workstation-v0/toolbox/sourceos-aur`: creates an Arch toolbox container and installs `yay`.
- `toolbox/README.md`: documents the trust boundary and usage.

This keeps AUR installs out of the host SYSTEM layer while still enabling access to AUR-only tools when needed.
