### PR TITLE
linux-dev: add workstation-v0 profile (manifest + installer + doctor + shell spine)

### DIFF
--- a/profiles/linux-dev/workstation-v0/README.md
+++ b/profiles/linux-dev/workstation-v0/README.md
@@ -1,0 +1,30 @@
+# linux-dev / workstation-v0
+
+This directory realizes the **Workstation Profile v0** for the `linux-dev` channel.
+
+It is a *host/profile realization surface* (per `docs/repository-layout.md`) rather than the canonical design/RFC.
+
+Design/RFC source of truth:
+- `SociOS-Linux/enhancements` → SourceOS Workstation Profile v0
+
+Typed contract boundary:
+- `SourceOS-Linux/sourceos-spec` (ADR 0001)
+
+## What this profile provides
+
+- A modern CLI-first tool bundle
+- A shell UX spine (fzf/atuin/zoxide/direnv + clipboard helpers)
+- Optional toolbox/AUR bridge for immutable hosts
+- A local `sourceos` helper CLI
+
+## Apply
+
+```bash
+./install.sh
+```
+
+## Verify
+
+```bash
+./doctor.sh
+```

--- a/profiles/linux-dev/workstation-v0/doctor.sh
+++ b/profiles/linux-dev/workstation-v0/doctor.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fail=0
+
+info(){ printf "INFO: %s\n" "$*" >&2; }
+err(){ printf "ERROR: %s\n" "$*" >&2; fail=1; }
+
+have(){ command -v "$1" >/dev/null 2>&1; }
+
+check(){
+  local bin=$1
+  if have "$bin"; then
+    info "ok: $bin"
+  else
+    err "missing: $bin"
+  fi
+}
+
+main(){
+  info "doctor: linux-dev/workstation-v0"
+
+  # SYSTEM expectations
+  check git
+  check ssh
+  check podman
+  check toolbox
+  check wl-copy
+  check jq
+
+  # X11 fallback clipboard
+  if have xclip; then
+    info "ok: xclip"
+  else
+    info "note: xclip missing (only needed on X11)"
+  fi
+
+  # USER expectations
+  check brew
+
+  # Core CLI must-haves
+  check fzf
+  check atuin
+  check bat
+  check zoxide
+  check eza
+  check yazi
+  check gum
+  check direnv
+  check rg
+  check fd
+  check tmux
+  check lazygit
+  check gh
+  check tig
+
+  # Additional
+  check sesh
+  check procs
+  check sd
+  check entr
+  check curlie
+
+  # JSON
+  check jnv
+  check gojq
+
+  # File motion
+  check rclone
+  check mc
+  check rsync
+
+  if [[ $fail -ne 0 ]]; then
+    info "doctor: FAIL"
+    exit 2
+  fi
+
+  info "doctor: OK"
+}
+
+main "$@"

--- a/profiles/linux-dev/workstation-v0/install.sh
+++ b/profiles/linux-dev/workstation-v0/install.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROFILE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MANIFEST="$PROFILE_DIR/manifest.yaml"
+
+err(){ printf "ERROR: %s\n" "$*" >&2; }
+info(){ printf "INFO: %s\n" "$*" >&2; }
+
+have(){ command -v "$1" >/dev/null 2>&1; }
+
+install_system(){
+  if have rpm-ostree; then
+    info "rpm-ostree detected: installing minimal SYSTEM layer (may require reboot)"
+    sudo rpm-ostree install git openssh-clients podman toolbox wl-clipboard jq xclip || true
+    info "If new packages were layered, reboot before continuing."
+    return
+  fi
+  if have dnf; then
+    info "dnf detected: installing minimal SYSTEM layer"
+    sudo dnf install -y git openssh-clients podman toolbox wl-clipboard jq xclip || true
+    return
+  fi
+  err "No rpm-ostree/dnf found; cannot apply SYSTEM layer"
+  exit 2
+}
+
+install_brew(){
+  err "brew not found. Install Homebrew/Linuxbrew, then re-run."
+  err "macOS: https://brew.sh"
+  err "Linuxbrew: https://docs.brew.sh/Homebrew-on-Linux"
+  exit 2
+}
+
+install_user(){
+  if ! have brew; then
+    install_brew
+  fi
+  info "Installing USER packages via brew (manifest-driven)."
+  awk '
+    $0 ~ /^\s*brew:\s*$/ {in=1; next}
+    in && $0 ~ /^\s*- / {gsub(/^\s*- /, ""); print; next}
+    in && $0 ~ /^\s*[^-[:space:]]/ {exit}
+  ' "$MANIFEST" | while read -r pkg; do
+    [[ -z "$pkg" ]] && continue
+    info "brew install $pkg"
+    brew install "$pkg" || true
+  done
+}
+
+install_shell_spine(){
+  local dst="${XDG_CONFIG_HOME:-$HOME/.config}/sourceos/shell"
+  mkdir -p "$dst"
+  cp -f "$PROFILE_DIR/shell/common.sh" "$dst/common.sh"
+  info "shell spine installed: $dst/common.sh"
+  info "Enable by sourcing it from your shell rc (zshrc/bashrc)."
+}
+
+main(){
+  [[ -f "$MANIFEST" ]] || { err "manifest missing: $MANIFEST"; exit 2; }
+  install_system
+  install_user
+  install_shell_spine
+  info "installed workstation-v0 (linux-dev)"
+  info "next: ./doctor.sh"
+}
+
+main "$@"

--- a/profiles/linux-dev/workstation-v0/manifest.yaml
+++ b/profiles/linux-dev/workstation-v0/manifest.yaml
@@ -1,0 +1,79 @@
+apiVersion: sourceos.workstation/v0
+kind: WorkstationProfile
+metadata:
+  name: workstation-v0
+  channel: linux-dev
+spec:
+  layers:
+    system:
+      rpm_ostree:
+        - git
+        - openssh-clients
+        - podman
+        - toolbox
+        - wl-clipboard
+        - jq
+        - xclip
+      dnf:
+        - git
+        - openssh-clients
+        - podman
+        - toolbox
+        - wl-clipboard
+        - jq
+        - xclip
+    user:
+      brew:
+        - fzf
+        - atuin
+        - bat
+        - zoxide
+        - yazi
+        - eza
+        - gum
+        - direnv
+        - tldr
+        - fd
+        - ripgrep
+        - sd
+        - lazygit
+        - gh
+        - diff-so-fancy
+        - tig
+        - svu
+        - tmux
+        - sesh
+        - mprocs
+        - procs
+        - lazydocker
+        - k9s
+        - btop
+        - jnv
+        - gojq
+        - fx
+        - jless
+        - jqp
+        - dua-cli
+        - dust
+        - kondo
+        - glow
+        - hyperfine
+        - rclone
+        - minio-mc
+        - rsync
+        - entr
+        - curlie
+  desktop:
+    gnome:
+      inputs:
+        kinto:
+          enabled: true
+          note: "X11-centric; validate Wayland or use keyd/xremap"
+        fusuma:
+          enabled: true
+          note: "libinput gestures; validate hardware"
+  launcher:
+    albert:
+      plugin:
+        id: sourceos
+        trigger: "sourceos "

--- a/profiles/linux-dev/workstation-v0/shell/common.sh
+++ b/profiles/linux-dev/workstation-v0/shell/common.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Common shell spine for SourceOS Workstation Profile v0
+# Safe to source multiple times.
+
+if [[ -n "${SOURCEOS_SHELL_SPINE_LOADED:-}" ]]; then
+  return 0 2>/dev/null || true
+fi
+export SOURCEOS_SHELL_SPINE_LOADED=1
+
+# --- direnv ---
+if command -v direnv >/dev/null 2>&1; then
+  if [[ -n "${ZSH_VERSION:-}" ]]; then
+    eval "$(direnv hook zsh)"
+  elif [[ -n "${BASH_VERSION:-}" ]]; then
+    eval "$(direnv hook bash)"
+  fi
+fi
+
+# --- atuin ---
+if command -v atuin >/dev/null 2>&1; then
+  if [[ -n "${ZSH_VERSION:-}" ]]; then
+    eval "$(atuin init zsh --disable-up-arrow)"
+  elif [[ -n "${BASH_VERSION:-}" ]]; then
+    eval "$(atuin init bash --disable-up-arrow)"
+  fi
+fi
+
+# --- zoxide ---
+if command -v zoxide >/dev/null 2>&1; then
+  if [[ -n "${ZSH_VERSION:-}" ]]; then
+    eval "$(zoxide init zsh)"
+  elif [[ -n "${BASH_VERSION:-}" ]]; then
+    eval "$(zoxide init bash)"
+  fi
+  alias cd='z' 2>/dev/null || true
+fi
+
+# --- fzf defaults (fd-backed) ---
+if command -v fzf >/dev/null 2>&1; then
+  if command -v fd >/dev/null 2>&1; then
+    export FZF_DEFAULT_COMMAND='fd --hidden --follow --exclude .git'
+    export FZF_CTRL_T_COMMAND="$FZF_DEFAULT_COMMAND"
+    export FZF_ALT_C_COMMAND='fd --type d --hidden --follow --exclude .git'
+  fi
+  export FZF_DEFAULT_OPTS='--height 40% --layout=reverse --border'
+fi
+
+# --- ergonomic aliases ---
+if command -v eza >/dev/null 2>&1; then
+  alias ls='eza --group-directories-first --icons' 2>/dev/null || true
+  alias ll='eza -lah --group-directories-first --icons' 2>/dev/null || true
+fi
+if command -v bat >/dev/null 2>&1; then
+  alias cat='bat' 2>/dev/null || true
+fi
+if command -v yazi >/dev/null 2>&1; then
+  alias y='yazi' 2>/dev/null || true
+fi
+
+# --- clipboard abstraction ---
+clipcopy() {
+  if command -v pbcopy >/dev/null 2>&1; then
+    pbcopy
+  elif command -v wl-copy >/dev/null 2>&1; then
+    wl-copy
+  elif command -v xclip >/dev/null 2>&1; then
+    xclip -selection clipboard
+  else
+    echo "No clipboard tool found (pbcopy/wl-copy/xclip)" >&2
+    return 1
+  fi
+}
+
+clippaste() {
+  if command -v pbpaste >/dev/null 2>&1; then
+    pbpaste
+  elif command -v wl-paste >/dev/null 2>&1; then
+    wl-paste
+  elif command -v xclip >/dev/null 2>&1; then
+    xclip -selection clipboard -o
+  else
+    echo "No clipboard tool found (pbpaste/wl-paste/xclip)" >&2
+    return 1
+  fi
+}


### PR DESCRIPTION
Implements the Workstation Profile v0 as a concrete `linux-dev` realization surface.

Adds:
- `profiles/linux-dev/workstation-v0/manifest.yaml`
- `install.sh` (SYSTEM via rpm-ostree/dnf; USER via brew)
- `doctor.sh`
- `shell/common.sh`

This aligns with the repository intent: `source-os` carries host/profile realization surfaces (not the canonical schema/policy plane). See `docs/agentplane-integration.md` and `docs/repository-layout.md`.

Design/RFC: SociOS-Linux/enhancements (Workstation Profile v0)
Typed boundary ADR: SourceOS-Linux/sourceos-spec (ADR 0001)
