### PR TITLE
docs(source-os): reserve Liberty Stack Linux substrate lane

### DIFF
--- a/build/liberty-stack/README.md
+++ b/build/liberty-stack/README.md
@@ -1,0 +1,23 @@
+# Liberty Stack build stub
+
+This directory reserves the first build- and host-facing realization surface for the Liberty Stack lane inside `source-os`.
+
+## Intended contents in follow-on tranches
+
+- service units or container definitions for first Liberty Stack components
+- host profile examples
+- bootstrap and validation helpers
+- packaging notes for Linux estate bring-up
+
+## First candidate components
+
+- headscale
+- step-ca
+- authentik
+- garage
+- sftpgo
+- restic
+
+## Current status
+
+This is a stub only. It exists so the Linux realization lane has a concrete build-side home before component-specific artifacts are landed.

--- a/build/liberty-stack/restic.env.example
+++ b/build/liberty-stack/restic.env.example
@@ -1,0 +1,2 @@
+RESTIC_REPOSITORY=/var/lib/source-os/liberty-stack/restic-repo
+RESTIC_PASSWORD_FILE=/etc/source-os/liberty-stack/restic-password

--- a/build/liberty-stack/scripts/liberty_stack_verify.sh
+++ b/build/liberty-stack/scripts/liberty_stack_verify.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${RESTIC_REPOSITORY:?RESTIC_REPOSITORY must be set}"
+: "${RESTIC_PASSWORD_FILE:?RESTIC_PASSWORD_FILE must be set}"
+
+restic snapshots >/dev/null
+restic check

--- a/build/liberty-stack/systemd/liberty-stack-verify.service
+++ b/build/liberty-stack/systemd/liberty-stack-verify.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Liberty Stack verification runner
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/lib/source-os/liberty-stack/liberty_stack_verify.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/build/liberty-stack/systemd/liberty-stack-verify.timer
+++ b/build/liberty-stack/systemd/liberty-stack-verify.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Schedule Liberty Stack verification
+
+[Timer]
+OnCalendar=daily
+Persistent=true
+Unit=liberty-stack-verify.service
+
+[Install]
+WantedBy=timers.target

--- a/docs/LIBERTY_STACK_COMPONENT_MAPPING.md
+++ b/docs/LIBERTY_STACK_COMPONENT_MAPPING.md
@@ -1,0 +1,38 @@
+# Liberty Stack component mapping
+
+## Purpose
+
+This note maps the upstream Liberty Stack standards and the downstream `prophet-platform` runtime lane onto candidate Linux host/substrate components in `source-os`.
+
+## Boundary
+
+- `socioprophet-agent-standards` remains the canonical semantic source of truth
+- `prophet-platform` remains the runtime/operator workflow surface
+- `source-os` is the Linux packaging, host profile, and service-composition layer
+
+## Candidate component mapping
+
+### Identity and trust
+- `authentik` — identity and auth surface
+- `step-ca` — host and service trust issuance
+
+### Reachability and overlay
+- `headscale` — private coordination plane for node reachability
+
+### Storage and access
+- `garage` — object storage substrate
+- `sftpgo` — multi-protocol access surface over storage
+
+### Backup and restore
+- `restic` — backup and restore execution surface
+
+## First substrate responsibilities
+
+The first `source-os` implementation tranche should make it possible to:
+1. declare the component set for one Liberty Stack host profile
+2. place service units or container definitions for the first component group
+3. attach validation notes for bootstrap and local bring-up
+
+## Deliberate limit
+
+This note is still a mapping surface. It does not yet freeze package managers, service managers, or deployment topology.

--- a/docs/LIBERTY_STACK_LINUX_SUBSTRATE.md
+++ b/docs/LIBERTY_STACK_LINUX_SUBSTRATE.md
@@ -1,0 +1,37 @@
+# Liberty Stack Linux substrate
+
+## Purpose
+
+This document reserves and defines the first Linux-substrate realization surface for the Liberty Stack lane inside `source-os`.
+
+The upstream semantic source of truth remains:
+- `SocioProphet/socioprophet-agent-standards` for AgentOS, M2, and Liberty Stack standards
+- `SocioProphet/prophet-platform` for runtime and operator-facing workflow consumption
+
+This repository is the Linux host and packaging realization layer.
+
+## Substrate responsibilities
+
+The Linux substrate slice should eventually cover:
+- host profile and package requirements
+- service composition for local-first liberty stack components
+- systemd or container service units
+- configuration placement and secret reference wiring
+- bootstrap and validation flows for Linux workstations and nodes
+
+## First candidate components
+
+The first substrate slice is expected to carry host-facing integration for components such as:
+- headscale
+- step-ca
+- authentik
+- garage
+- sftpgo
+- restic
+- supporting validation and bootstrap helpers
+
+## Deliberate limits
+
+This note does not make `source-os` a second standards authority.
+
+It exists to keep the Linux realization boundary explicit so packaging, service units, and host bootstrap logic do not drift back into the standards repo or the platform runtime repo.


### PR DESCRIPTION
## Summary

Add the first explicit Linux-substrate placement note for the Liberty Stack lane in `source-os`.

## Why

The ecosystem now has:
- upstream standards in `SocioProphet/socioprophet-agent-standards`
- downstream runtime/operator consumption in `SocioProphet/prophet-platform`

What was still missing was the Linux host/substrate realization boundary in `source-os`.

This PR adds that boundary note so packaging, service composition, and host bootstrap logic have a clear home.

## What this PR adds

- `docs/LIBERTY_STACK_LINUX_SUBSTRATE.md`

## Intentional limits

This PR is documentation-only.
It does not yet add service units, package manifests, container compositions, or bootstrap scripts.

Those should follow after the substrate boundary is accepted.
