### PR TITLE
build(source-os): wire mesh runtime ownership and services

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -67,6 +67,7 @@
             '';
 
           mesh-module-contract = import ./tests/mesh-module-contract.nix { inherit pkgs; };
+          mesh-runtime-contract = import ./tests/mesh-runtime-contract.nix { inherit pkgs; };
         });
 
       sourceos = {

--- a/modules/nixos/mesh/default.nix
+++ b/modules/nixos/mesh/default.nix
@@ -1,9 +1,16 @@
-{ config, lib, ... }:
+{ config, lib, pkgs, ... }:
 let
   cfg = config.sourceos.mesh;
 
   unique = values:
     lib.length values == lib.length (lib.unique values);
+
+  runtimeEnabled = cfg.runtime.enable;
+  exitRuntimeEnabled = runtimeEnabled && cfg.runtime.enableExitHelper && cfg.role == "exit";
+
+  runtimeConfigDir = "/etc/${cfg.runtime.configDirectory}";
+  runtimeNftDir = "${runtimeConfigDir}/nftables";
+  runtimeSocketDir = "/run/${cfg.runtime.runtimeDirectoryName}";
 
   netdevTemplate =
     lib.replaceStrings
@@ -55,6 +62,37 @@ let
       ]
       (builtins.readFile ../../../linux/networkmanager/wg-mesh.nmconnection);
 
+  meshdConfigText = ''
+    [identity]
+    role = "${cfg.role}"
+    manager = "${cfg.manager}"
+    interface = "${cfg.interfaceName}"
+
+    [paths]
+    manifest = "/etc/sourceos/mesh/manifest.json"
+    control_socket = "unix:${runtimeSocketDir}/meshd.sock"
+    link_socket = "unix:${runtimeSocketDir}/linkd.sock"
+
+    [routing]
+    private_fwmark = "${cfg.fwmarks.private}"
+    exit_fwmark = "${cfg.fwmarks.exit}"
+    private_route_table = ${toString cfg.routeTables.private}
+    exit_route_table = ${toString cfg.routeTables.exit}
+    onion_route_table = ${toString cfg.routeTables.onion}
+    mix_route_table = ${toString cfg.routeTables.mix}
+  '';
+
+  exitdConfigText = ''
+    [exit]
+    interface = "${cfg.interfaceName}"
+    nft_policy = "${runtimeNftDir}/mesh-exit.nft"
+    allow_full_tunnel = ${if cfg.role == "exit" then "true" else "false"}
+
+    [routing]
+    exit_fwmark = "${cfg.fwmarks.exit}"
+    exit_route_table = ${toString cfg.routeTables.exit}
+  '';
+
   manifestJson = builtins.toJSON {
     version = "sourceos-mesh-realization/v0";
     role = cfg.role;
@@ -64,6 +102,12 @@ let
     fwmarks = cfg.fwmarks;
     activateTemplates = cfg.activateTemplates;
     pathTemplates = [ "P0-direct" "P1-relay" "P2-microcascade" "P3-onion" "P4-mix" ];
+    runtime = {
+      enabled = runtimeEnabled;
+      exitHelperEnabled = exitRuntimeEnabled;
+      configDirectory = runtimeConfigDir;
+      socketDirectory = runtimeSocketDir;
+    };
   };
 in
 {
@@ -146,6 +190,73 @@ in
       };
     };
 
+    runtime = {
+      enable = lib.mkEnableOption "mesh runtime services";
+
+      enableExitHelper = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = "Enable the exit helper automatically when runtime services are enabled on an exit-role host.";
+      };
+
+      manageUsers = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = "Manage the meshd system user and group from the NixOS module.";
+      };
+
+      user = lib.mkOption {
+        type = lib.types.str;
+        default = "meshd";
+        description = "User account used by the unprivileged mesh control-plane daemon.";
+      };
+
+      group = lib.mkOption {
+        type = lib.types.str;
+        default = "meshd";
+        description = "Primary group used by the unprivileged mesh control-plane daemon.";
+      };
+
+      stateDirectoryName = lib.mkOption {
+        type = lib.types.str;
+        default = "meshd";
+        description = "StateDirectory name for meshd runtime state.";
+      };
+
+      runtimeDirectoryName = lib.mkOption {
+        type = lib.types.str;
+        default = "meshd";
+        description = "RuntimeDirectory name for meshd sockets and short-lived state.";
+      };
+
+      configDirectory = lib.mkOption {
+        type = lib.types.str;
+        default = "meshd";
+        description = "Relative directory name under /etc used for runtime configuration material.";
+      };
+
+      meshdPackage = lib.mkOption {
+        type = lib.types.nullOr lib.types.package;
+        default = null;
+        example = lib.literalExpression "pkgs.meshd";
+        description = "Package providing the `meshd` executable.";
+      };
+
+      linkdPackage = lib.mkOption {
+        type = lib.types.nullOr lib.types.package;
+        default = null;
+        example = lib.literalExpression "pkgs.meshd-linkd";
+        description = "Package providing the `meshd-linkd` executable.";
+      };
+
+      exitdPackage = lib.mkOption {
+        type = lib.types.nullOr lib.types.package;
+        default = null;
+        example = lib.literalExpression "pkgs.meshd-exitd";
+        description = "Package providing the `meshd-exitd` executable.";
+      };
+    };
+
     realize = {
       networkTemplates = lib.mkOption {
         type = lib.types.bool;
@@ -177,7 +288,27 @@ in
         assertion = unique [ cfg.fwmarks.private cfg.fwmarks.exit cfg.fwmarks.onion cfg.fwmarks.mix ];
         message = "sourceos.mesh.fwmarks values must be unique.";
       }
+      {
+        assertion = (!runtimeEnabled) || (cfg.runtime.meshdPackage != null && cfg.runtime.linkdPackage != null);
+        message = "sourceos.mesh.runtime.enable requires both sourceos.mesh.runtime.meshdPackage and sourceos.mesh.runtime.linkdPackage.";
+      }
+      {
+        assertion = (!exitRuntimeEnabled) || (cfg.runtime.exitdPackage != null);
+        message = "sourceos.mesh runtime exit-helper enablement requires sourceos.mesh.runtime.exitdPackage on exit-role hosts.";
+      }
     ];
+
+    users.groups = lib.optionalAttrs (runtimeEnabled && cfg.runtime.manageUsers) {
+      "${cfg.runtime.group}" = {};
+    };
+
+    users.users = lib.optionalAttrs (runtimeEnabled && cfg.runtime.manageUsers) {
+      "${cfg.runtime.user}" = {
+        isSystemUser = true;
+        group = cfg.runtime.group;
+        description = "SourceOS mesh control-plane daemon user";
+      };
+    };
 
     environment.etc = lib.mkMerge [
       {
@@ -187,8 +318,13 @@ in
           Role: ${cfg.role}
           Manager: ${cfg.manager}
           Interface: ${cfg.interfaceName}
+          Runtime enabled: ${if runtimeEnabled then "yes" else "no"}
         '';
+        "sourceos/mesh/runtime/meshd.toml".text = meshdConfigText;
       }
+      (lib.optionalAttrs exitRuntimeEnabled {
+        "sourceos/mesh/runtime/exits.toml".text = exitdConfigText;
+      })
       (lib.optionalAttrs cfg.realize.networkTemplates {
         "sourceos/mesh/systemd-networkd/50-${cfg.interfaceName}.netdev".text = netdevTemplate;
         "sourceos/mesh/systemd-networkd/50-${cfg.interfaceName}.network".text = networkTemplate;
@@ -214,9 +350,118 @@ in
         "systemd/system/meshd-linkd.service".source = ../../../linux/systemd/meshd-linkd.service;
         "systemd/system/meshd-exitd.service".source = ../../../linux/systemd/meshd-exitd.service;
       })
+      (lib.optionalAttrs (cfg.activateTemplates && runtimeEnabled) {
+        "${cfg.runtime.configDirectory}/meshd.toml".text = meshdConfigText;
+      })
+      (lib.optionalAttrs (cfg.activateTemplates && exitRuntimeEnabled) {
+        "${cfg.runtime.configDirectory}/exits.toml".text = exitdConfigText;
+      })
       (lib.optionalAttrs (cfg.activateTemplates && cfg.role == "exit" && cfg.realize.nftablesExit) {
-        "nftables.d/mesh-exit.nft".source = ../../../linux/nftables/mesh-exit.nft;
+        "${cfg.runtime.configDirectory}/nftables/mesh-exit.nft".source = ../../../linux/nftables/mesh-exit.nft;
       })
     ];
+
+    systemd.services.meshd = lib.mkIf runtimeEnabled {
+      description = "Mesh control-plane daemon";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
+      serviceConfig = {
+        Type = "notify";
+        User = cfg.runtime.user;
+        Group = cfg.runtime.group;
+        StateDirectory = cfg.runtime.stateDirectoryName;
+        RuntimeDirectory = cfg.runtime.runtimeDirectoryName;
+        ExecStart = "${cfg.runtime.meshdPackage}/bin/meshd --config ${runtimeConfigDir}/meshd.toml --listen unix:${runtimeSocketDir}/meshd.sock";
+        Restart = "on-failure";
+        RestartSec = "2s";
+        NoNewPrivileges = true;
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        PrivateTmp = true;
+        PrivateDevices = true;
+        ProtectControlGroups = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectClock = true;
+        ProtectHostname = true;
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        RestrictSUIDSGID = true;
+        RestrictRealtime = true;
+        RestrictNamespaces = true;
+        SystemCallArchitectures = "native";
+        RestrictAddressFamilies = [ "AF_UNIX" "AF_INET" "AF_INET6" ];
+        CapabilityBoundingSet = "";
+        AmbientCapabilities = "";
+      };
+    };
+
+    systemd.services.meshd-linkd = lib.mkIf runtimeEnabled {
+      description = "Mesh privileged link helper";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "meshd.service" ];
+      requires = [ "meshd.service" ];
+      serviceConfig = {
+        Type = "notify";
+        User = "root";
+        Group = "root";
+        RuntimeDirectory = cfg.runtime.runtimeDirectoryName;
+        ExecStart = "${cfg.runtime.linkdPackage}/bin/meshd-linkd --rpc unix:${runtimeSocketDir}/linkd.sock --control unix:${runtimeSocketDir}/meshd.sock";
+        Restart = "on-failure";
+        RestartSec = "2s";
+        NoNewPrivileges = true;
+        PrivateTmp = true;
+        PrivateDevices = true;
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        ProtectControlGroups = true;
+        ProtectKernelLogs = true;
+        ProtectClock = true;
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        RestrictSUIDSGID = true;
+        RestrictRealtime = true;
+        RestrictNamespaces = true;
+        SystemCallArchitectures = "native";
+        RestrictAddressFamilies = [ "AF_UNIX" "AF_NETLINK" "AF_INET" "AF_INET6" ];
+        CapabilityBoundingSet = [ "CAP_NET_ADMIN" "CAP_NET_RAW" ];
+        AmbientCapabilities = [ "CAP_NET_ADMIN" "CAP_NET_RAW" ];
+      };
+    };
+
+    systemd.services.meshd-exitd = lib.mkIf exitRuntimeEnabled {
+      description = "Mesh exit helper";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network-online.target" "meshd-linkd.service" ];
+      wants = [ "network-online.target" ];
+      requires = [ "meshd-linkd.service" ];
+      serviceConfig = {
+        Type = "simple";
+        User = "root";
+        Group = "root";
+        ExecStart = "${cfg.runtime.exitdPackage}/bin/meshd-exitd --config ${runtimeConfigDir}/exits.toml --nft ${runtimeNftDir}/mesh-exit.nft";
+        Restart = "on-failure";
+        RestartSec = "2s";
+        NoNewPrivileges = true;
+        PrivateTmp = true;
+        PrivateDevices = true;
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        ProtectControlGroups = true;
+        ProtectKernelLogs = true;
+        ProtectClock = true;
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        RestrictSUIDSGID = true;
+        RestrictRealtime = true;
+        RestrictNamespaces = true;
+        SystemCallArchitectures = "native";
+        RestrictAddressFamilies = [ "AF_UNIX" "AF_NETLINK" "AF_INET" "AF_INET6" ];
+        CapabilityBoundingSet = [ "CAP_NET_ADMIN" "CAP_NET_RAW" ];
+        AmbientCapabilities = [ "CAP_NET_ADMIN" "CAP_NET_RAW" ];
+      };
+    };
   };
 }

--- a/tests/mesh-runtime-contract.nix
+++ b/tests/mesh-runtime-contract.nix
@@ -1,0 +1,17 @@
+{ pkgs ? import <nixpkgs> {} }:
+pkgs.runCommand "mesh-runtime-contract" {
+  nativeBuildInputs = [ pkgs.gnugrep ];
+} ''
+  grep -q 'sourceos.mesh.runtime' ${../modules/nixos/mesh/default.nix}
+  grep -q 'meshdPackage' ${../modules/nixos/mesh/default.nix}
+  grep -q 'linkdPackage' ${../modules/nixos/mesh/default.nix}
+  grep -q 'exitdPackage' ${../modules/nixos/mesh/default.nix}
+  grep -q 'users.users' ${../modules/nixos/mesh/default.nix}
+  grep -q 'systemd.services.meshd =' ${../modules/nixos/mesh/default.nix}
+  grep -q 'systemd.services.meshd-linkd =' ${../modules/nixos/mesh/default.nix}
+  grep -q 'systemd.services.meshd-exitd =' ${../modules/nixos/mesh/default.nix}
+  grep -q 'sourceos/mesh/runtime/meshd.toml' ${../modules/nixos/mesh/default.nix}
+  grep -q 'runtime.enable requires both' ${../modules/nixos/mesh/default.nix}
+  mkdir -p $out
+  echo validated > $out/result.txt
+''


### PR DESCRIPTION
## Summary

Implement the next tranche after the merged mesh NixOS realization module.

This PR adds:
- runtime ownership and package options under `sourceos.mesh.runtime`
- generated runtime config surfaces for `meshd` and the exit helper
- Nix-native `systemd.services` definitions for `meshd`, `meshd-linkd`, and `meshd-exitd`
- managed `meshd` system user/group support
- a flake contract check for the runtime/service layer

## What this does

The mesh module now goes beyond template realization.
When `sourceos.mesh.runtime.enable = true`, it can:
- manage the `meshd` system identity
- generate runtime config files under `/etc/sourceos/mesh/` and optionally project them into `/etc/meshd/`
- define the actual systemd services for the control-plane daemon, privileged link helper, and exit helper

This is still intentionally honest:
- services are only valid when packages are explicitly supplied
- assertions fail closed if runtime enablement is requested without the required packages
- profiles do not auto-enable runtime yet

## Why this shape

This turns the mesh module into a real host-composition surface without pretending the daemon packages or confinement layers are already complete.

## Follow-up still needed

Tracked in #15:
- actual package ownership for `meshd`, `meshd-linkd`, and `meshd-exitd`
- host-role defaults that selectively enable runtime where appropriate
- SELinux / AppArmor confinement
- support-matrix freeze
- stronger CI that evaluates the module path, not just the text contract
