### PR TITLE
build(source-os): add mesh daemon packages and host runtime defaults

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -82,6 +82,10 @@
           mesh-runtime-contract = import ./tests/mesh-runtime-contract.nix { inherit pkgs; };
           mesh-package-contract = import ./tests/mesh-package-contract.nix { inherit pkgs; };
           mesh-host-runtime-contract = import ./tests/mesh-host-runtime-contract.nix { inherit pkgs; };
+
+          meshd-package = self.packages.${system}.meshd;
+          meshd-linkd-package = self.packages.${system}.meshd-linkd;
+          meshd-exitd-package = self.packages.${system}.meshd-exitd;
         });
 
       sourceos = {

--- a/flake.nix
+++ b/flake.nix
@@ -13,6 +13,15 @@
     in {
       formatter = forAllSystems (system: nixpkgs.legacyPackages.${system}.nixpkgs-fmt);
 
+      packages = forAllSystems (system:
+        let pkgs = nixpkgs.legacyPackages.${system};
+        in rec {
+          meshd = pkgs.callPackage ./packages/mesh/meshd.nix { };
+          meshd-linkd = pkgs.callPackage ./packages/mesh/meshd-linkd.nix { };
+          meshd-exitd = pkgs.callPackage ./packages/mesh/meshd-exitd.nix { };
+          default = meshd;
+        });
+
       devShells = forAllSystems (system:
         let pkgs = nixpkgs.legacyPackages.${system};
         in {
@@ -28,16 +37,19 @@
       nixosConfigurations = {
         builder-aarch64 = lib.nixosSystem {
           system = "aarch64-linux";
+          specialArgs = { inherit self; };
           modules = [ ./hosts/builder-aarch64/default.nix ];
         };
 
         canary-x86_64 = lib.nixosSystem {
           system = "x86_64-linux";
+          specialArgs = { inherit self; };
           modules = [ ./hosts/canary-x86_64/default.nix ];
         };
 
         stable-x86_64 = lib.nixosSystem {
           system = "x86_64-linux";
+          specialArgs = { inherit self; };
           modules = [ ./hosts/stable-x86_64/default.nix ];
         };
       };
@@ -68,6 +80,8 @@
 
           mesh-module-contract = import ./tests/mesh-module-contract.nix { inherit pkgs; };
           mesh-runtime-contract = import ./tests/mesh-runtime-contract.nix { inherit pkgs; };
+          mesh-package-contract = import ./tests/mesh-package-contract.nix { inherit pkgs; };
+          mesh-host-runtime-contract = import ./tests/mesh-host-runtime-contract.nix { inherit pkgs; };
         });
 
       sourceos = {

--- a/hosts/canary-x86_64/default.nix
+++ b/hosts/canary-x86_64/default.nix
@@ -1,4 +1,4 @@
-{ ... }:
+{ self, pkgs, ... }:
 {
   imports = [
     ../../profiles/linux-candidate/default.nix
@@ -9,5 +9,11 @@
   sourceos.build = {
     role = "canary-x86_64";
     channel = "candidate";
+  };
+
+  sourceos.mesh.runtime = {
+    enable = true;
+    meshdPackage = self.packages.${pkgs.system}.meshd;
+    linkdPackage = self.packages.${pkgs.system}.meshd-linkd;
   };
 }

--- a/hosts/stable-x86_64/default.nix
+++ b/hosts/stable-x86_64/default.nix
@@ -1,4 +1,4 @@
-{ ... }:
+{ self, pkgs, ... }:
 {
   imports = [
     ../../profiles/linux-stable/default.nix
@@ -9,5 +9,11 @@
   sourceos.build = {
     role = "stable-x86_64";
     channel = "stable";
+  };
+
+  sourceos.mesh.runtime = {
+    enable = true;
+    meshdPackage = self.packages.${pkgs.system}.meshd;
+    linkdPackage = self.packages.${pkgs.system}.meshd-linkd;
   };
 }

--- a/packages/mesh/meshd-exitd.nix
+++ b/packages/mesh/meshd-exitd.nix
@@ -1,0 +1,39 @@
+{ writeShellApplication, coreutils }:
+writeShellApplication {
+  name = "meshd-exitd";
+  runtimeInputs = [ coreutils ];
+  text = ''
+    set -euo pipefail
+
+    CONFIG=""
+    NFT=""
+
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        --config)
+          CONFIG="$2"
+          shift 2
+          ;;
+        --nft)
+          NFT="$2"
+          shift 2
+          ;;
+        *)
+          shift
+          ;;
+      esac
+    done
+
+    if [ -z "$CONFIG" ] || [ ! -f "$CONFIG" ]; then
+      echo "meshd-exitd: missing or unreadable --config path" >&2
+      exit 2
+    fi
+
+    if [ -z "$NFT" ] || [ ! -f "$NFT" ]; then
+      echo "meshd-exitd: missing or unreadable --nft path" >&2
+      exit 2
+    fi
+
+    exec sleep infinity
+  '';
+}

--- a/packages/mesh/meshd-linkd.nix
+++ b/packages/mesh/meshd-linkd.nix
@@ -1,0 +1,93 @@
+{ writeShellApplication, python3, systemd, coreutils }:
+writeShellApplication {
+  name = "meshd-linkd";
+  runtimeInputs = [ python3 systemd coreutils ];
+  text = ''
+    set -euo pipefail
+
+    RPC=""
+    CONTROL=""
+
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        --rpc)
+          RPC="$2"
+          shift 2
+          ;;
+        --control)
+          CONTROL="$2"
+          shift 2
+          ;;
+        *)
+          shift
+          ;;
+      esac
+    done
+
+    case "$RPC" in
+      unix:*) RPC_PATH="${RPC#unix:}" ;;
+      *) echo "meshd-linkd: --rpc must be a unix: URI" >&2; exit 2 ;;
+    esac
+
+    case "$CONTROL" in
+      unix:*) CONTROL_PATH="${CONTROL#unix:}" ;;
+      *) echo "meshd-linkd: --control must be a unix: URI" >&2; exit 2 ;;
+    esac
+
+    mkdir -p "$(dirname "$RPC_PATH")"
+
+    exec python3 - "$RPC_PATH" "$CONTROL_PATH" <<'PY'
+import os
+import select
+import signal
+import socket
+import subprocess
+import sys
+import time
+
+rpc_path = sys.argv[1]
+control_path = sys.argv[2]
+stop = False
+
+def _stop(*_args):
+    global stop
+    stop = True
+
+signal.signal(signal.SIGTERM, _stop)
+signal.signal(signal.SIGINT, _stop)
+
+for _ in range(30):
+    if os.path.exists(control_path):
+        break
+    time.sleep(1)
+
+try:
+    os.unlink(rpc_path)
+except FileNotFoundError:
+    pass
+
+srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+srv.bind(rpc_path)
+srv.listen(8)
+
+if os.environ.get("NOTIFY_SOCKET"):
+    subprocess.run([
+        "systemd-notify",
+        "--ready",
+        f"--status=meshd-linkd bootstrap active ({rpc_path})"
+    ], check=False)
+
+while not stop:
+    ready, _, _ = select.select([srv], [], [], 1.0)
+    if srv in ready:
+        conn, _ = srv.accept()
+        conn.close()
+
+srv.close()
+try:
+    os.unlink(rpc_path)
+except FileNotFoundError:
+    pass
+PY
+  '';
+}

--- a/packages/mesh/meshd.nix
+++ b/packages/mesh/meshd.nix
@@ -1,0 +1,93 @@
+{ writeShellApplication, python3, systemd, coreutils }:
+writeShellApplication {
+  name = "meshd";
+  runtimeInputs = [ python3 systemd coreutils ];
+  text = ''
+    set -euo pipefail
+
+    CONFIG=""
+    LISTEN=""
+
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        --config)
+          CONFIG="$2"
+          shift 2
+          ;;
+        --listen)
+          LISTEN="$2"
+          shift 2
+          ;;
+        *)
+          shift
+          ;;
+      esac
+    done
+
+    if [ -z "$CONFIG" ] || [ ! -f "$CONFIG" ]; then
+      echo "meshd: missing or unreadable --config path" >&2
+      exit 2
+    fi
+
+    case "$LISTEN" in
+      unix:*)
+        SOCKET_PATH="${LISTEN#unix:}"
+        ;;
+      *)
+        echo "meshd: only unix: listeners are supported by this bootstrap package" >&2
+        exit 2
+        ;;
+    esac
+
+    mkdir -p "$(dirname "$SOCKET_PATH")"
+
+    exec python3 - "$CONFIG" "$SOCKET_PATH" <<'PY'
+import os
+import select
+import signal
+import socket
+import subprocess
+import sys
+
+config_path = sys.argv[1]
+socket_path = sys.argv[2]
+
+stop = False
+
+def _stop(*_args):
+    global stop
+    stop = True
+
+signal.signal(signal.SIGTERM, _stop)
+signal.signal(signal.SIGINT, _stop)
+
+try:
+    os.unlink(socket_path)
+except FileNotFoundError:
+    pass
+
+srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+srv.bind(socket_path)
+srv.listen(8)
+
+if os.environ.get("NOTIFY_SOCKET"):
+    subprocess.run([
+        "systemd-notify",
+        "--ready",
+        f"--status=meshd bootstrap active ({socket_path})"
+    ], check=False)
+
+while not stop:
+    ready, _, _ = select.select([srv], [], [], 1.0)
+    if srv in ready:
+        conn, _ = srv.accept()
+        conn.close()
+
+srv.close()
+try:
+    os.unlink(socket_path)
+except FileNotFoundError:
+    pass
+PY
+  '';
+}

--- a/tests/mesh-host-runtime-contract.nix
+++ b/tests/mesh-host-runtime-contract.nix
@@ -1,0 +1,16 @@
+{ pkgs ? import <nixpkgs> {} }:
+pkgs.runCommand "mesh-host-runtime-contract" {
+  nativeBuildInputs = [ pkgs.gnugrep ];
+} ''
+  grep -q 'specialArgs = { inherit self; };' ${../flake.nix}
+  grep -q '{ self, pkgs, ... }:' ${../hosts/canary-x86_64/default.nix}
+  grep -q '{ self, pkgs, ... }:' ${../hosts/stable-x86_64/default.nix}
+  grep -q 'sourceos.mesh.runtime = {' ${../hosts/canary-x86_64/default.nix}
+  grep -q 'sourceos.mesh.runtime = {' ${../hosts/stable-x86_64/default.nix}
+  grep -q 'meshdPackage = self.packages.${pkgs.system}.meshd;' ${../hosts/canary-x86_64/default.nix}
+  grep -q 'linkdPackage = self.packages.${pkgs.system}.meshd-linkd;' ${../hosts/canary-x86_64/default.nix}
+  grep -q 'meshdPackage = self.packages.${pkgs.system}.meshd;' ${../hosts/stable-x86_64/default.nix}
+  grep -q 'linkdPackage = self.packages.${pkgs.system}.meshd-linkd;' ${../hosts/stable-x86_64/default.nix}
+  mkdir -p $out
+  echo validated > $out/result.txt
+''

--- a/tests/mesh-package-contract.nix
+++ b/tests/mesh-package-contract.nix
@@ -1,0 +1,17 @@
+{ pkgs ? import <nixpkgs> {} }:
+pkgs.runCommand "mesh-package-contract" {
+  nativeBuildInputs = [ pkgs.gnugrep ];
+} ''
+  test -f ${../packages/mesh/meshd.nix}
+  test -f ${../packages/mesh/meshd-linkd.nix}
+  test -f ${../packages/mesh/meshd-exitd.nix}
+  grep -q 'packages = forAllSystems' ${../flake.nix}
+  grep -q 'meshd = pkgs.callPackage ./packages/mesh/meshd.nix' ${../flake.nix}
+  grep -q 'meshd-linkd = pkgs.callPackage ./packages/mesh/meshd-linkd.nix' ${../flake.nix}
+  grep -q 'meshd-exitd = pkgs.callPackage ./packages/mesh/meshd-exitd.nix' ${../flake.nix}
+  grep -q 'systemd-notify' ${../packages/mesh/meshd.nix}
+  grep -q 'systemd-notify' ${../packages/mesh/meshd-linkd.nix}
+  grep -q 'sleep infinity' ${../packages/mesh/meshd-exitd.nix}
+  mkdir -p $out
+  echo validated > $out/result.txt
+''


### PR DESCRIPTION
## Summary

Implement the next tranche after the merged runtime/service wiring.

This PR adds:
- Nix package surfaces for `meshd`, `meshd-linkd`, and `meshd-exitd`
- flake package outputs for those daemons
- `specialArgs = { inherit self; };` in host compositions so hosts can reference flake-local packages
- first role-aware runtime defaults for the canary peer and stable relay hosts
- package and host-runtime contract checks
- package build checks in `flake checks`

## What this does

The stack now moves one step closer to being runnable:
- the mesh module can compose against actual package outputs instead of hypothetical packages
- the canary and stable lanes have concrete runtime defaults
- CI can at least evaluate and realize the daemon package surfaces

## Scope honesty

These daemon packages are bootstrap implementations, not the final sovereign control plane.
They validate inputs, create the expected runtime surfaces, and stay service-compatible so the host layer can be exercised end-to-end.

## Follow-up still needed

Tracked in #15:
- replace bootstrap daemon implementations with real control-plane logic
- add role-aware exit host defaults once an exit host/profile exists
- add confinement
- freeze support matrix
- move from contract checks toward deeper evaluation and integration tests
