### PR TITLE
docs(storage): add foreign-volume linux estate integration tranche

### DIFF
--- a/docs/storage/README.md
+++ b/docs/storage/README.md
@@ -1,0 +1,16 @@
+# Storage Linux Estate Integration
+
+This directory carries the Linux-native realization material for storage and mount-surface work inside `source-os`.
+
+Placement rule:
+- Linux estate realization lives here.
+- Shared storage and mount-surface standards live in `SocioProphet/socioprophet-standards-storage`.
+- Typed resources and shared vocabulary should live in `SourceOS-Linux/sourceos-spec`.
+- Control-plane lifecycle and promotion semantics remain outside this directory unless they directly affect Linux storage realization.
+
+Contents:
+- `foreign_volume_linux_estate_upstream_plan.md` — Linux-native integration plan and role split for foreign-volume handling
+- `foreign_filesystem_policy_matrix.md` — filesystem classes, default posture, and Linux policy mapping
+- `upstream_workstreams.md` — staged upstream workstream plan
+
+Companion Linux-facing templates and packaging notes should live under `linux/` once the policy matrix is stable enough to realize concretely.

--- a/docs/storage/foreign_filesystem_policy_matrix.md
+++ b/docs/storage/foreign_filesystem_policy_matrix.md
@@ -1,0 +1,54 @@
+# Foreign Filesystem Policy Matrix
+
+## Rule of thumb
+
+If a foreign volume can be handled by read-only import plus copy-in to governed native storage, do that.
+
+## Filesystem classes
+
+| Filesystem / surface | Default class | Default posture | Linux realization notes |
+| --- | --- | --- | --- |
+| APFS host system/data volumes | foreign system volume | read-only import only | treat as foreign system state; do not use as mutable runtime state |
+| HFS+ journaled volumes | foreign system volume | read-only import only | treat journaled host volumes as import-only by default |
+| exFAT exchange partition | exchange volume | read-write only for exchange workflows | never use for substrate-sensitive state, audit stores, or host runtime state |
+| ext4/xfs/btrfs from another Linux host or distro | foreign Linux volume | read-only by default | allow read-write only when the trust domain and ownership model are explicitly declared |
+| boot-adjacent foreign assets | substrate-sensitive import | read-only import only | mutations require privileged substrate operations and explicit recovery intent |
+
+## Required default flags
+
+### Foreign system volumes
+
+Default posture SHOULD be equivalent to:
+- `ro`
+- `nodev`
+- `nosuid`
+- `noexec`
+
+### Exchange volumes
+
+Default posture SHOULD preserve:
+- `nodev`
+- `nosuid`
+
+Read-write MAY be allowed for explicit exchange workflows.
+Executable use SHOULD remain disabled unless a declared workload requires it and the trust model is documented.
+
+## Apple dual-boot rule
+
+On Apple dual-boot devices:
+- macOS system and data volumes are foreign system volumes
+- shared exchange partitions are separate exchange surfaces, not extensions of the host runtime
+- recovery and boot-adjacent foreign assets are substrate-sensitive imports
+
+## Container rule
+
+Foreign system volumes are forbidden in ordinary rootless container mounts by default.
+Exchange volumes MAY be bound into explicit import/export jobs where the policy class is declared.
+
+## Evidence rule
+
+Every governed foreign-volume workflow SHOULD emit enough evidence to reconstruct:
+- discovered filesystem type
+- assigned class
+- resulting mount posture
+- any explicit read-write exception

--- a/docs/storage/foreign_volume_linux_estate_upstream_plan.md
+++ b/docs/storage/foreign_volume_linux_estate_upstream_plan.md
@@ -1,0 +1,72 @@
+# Foreign Volume Linux Estate Upstream Plan
+
+## Goal
+
+Integrate foreign-volume and cross-OS mount policy into a Linux estate in a way that is upstream-friendly, operationally sane, evidence-bearing, and survivable under partial trust.
+
+The design separates four concerns:
+1. foreign filesystem classification
+2. mount posture and privilege boundaries
+3. import and exchange flows
+4. recovery and rollback implications
+
+## Linux-native constraints
+
+Release 1 should avoid inventing a bespoke storage daemon or kernel patch set.
+
+Use existing Linux primitives for what they already do well:
+- systemd mount and automount units for governed runtime surfaces
+- standard kernel mount flags and read-only posture by default
+- udev and existing discovery surfaces for partition visibility
+- packaging notes and user-space helpers for classification and import workflows
+
+Do not treat foreign host volumes as ordinary mutable service state in Release 1.
+Do not normalize risky read-write behavior for foreign system volumes.
+
+## Privilege split
+
+Use separate roles instead of one omnipotent helper:
+
+### Discovery and classification
+Unprivileged logic for identifying candidate volumes, filesystems, labels, and likely trust class.
+
+### Mount policy rendering
+Controlled logic that maps a classified surface into the allowed Linux mount posture.
+
+### Privileged mount execution
+A narrow privileged path for applying mount units or one-shot mounts with the declared safety flags.
+
+### Import and exchange jobs
+User-space import/export flows that copy data into governed native storage rather than mutating foreign system volumes in place.
+
+## Estate split
+
+### Workstations and dual-boot devices
+Prefer explicit discovery, operator-visible posture, and import-oriented workflows.
+
+### Headless servers and appliances
+Prefer policy-declared mounts only; avoid ambient foreign-volume handling except for explicit recovery, migration, or evidence workflows.
+
+## Release-1 scope
+
+### In scope
+- foreign filesystem classification
+- default read-only posture for foreign system volumes
+- explicit exchange-volume handling
+- Apple/macOS dual-boot policy mapping
+- Linux docs, matrices, packaging notes, and staged workstreams
+- evidence-bearing import and rollback guidance
+
+### Out of scope
+- automatic read-write support for risky foreign system filesystems
+- bespoke kernel filesystems
+- silent cross-OS mutation of boot-adjacent assets
+- broad container exposure of foreign host volumes
+
+## Repo placement in `source-os`
+
+- `docs/storage/` — design and rollout docs
+- `linux/packaging/` — packaging notes and future package split stubs
+- future Linux-facing templates under `linux/` only after the policy matrix stabilizes
+
+Shared normative standards remain in `SocioProphet/socioprophet-standards-storage`, not here.

--- a/docs/storage/storage_packaging_notes.md
+++ b/docs/storage/storage_packaging_notes.md
@@ -1,0 +1,29 @@
+# Storage Packaging Notes
+
+## Purpose
+
+This note records the likely Linux-facing runtime surfaces for foreign-volume and cross-OS mount realization work.
+
+It is intentionally packaging-oriented and does not yet prescribe a concrete generator, daemon, or mount-unit layout.
+
+## Recommended runtime surfaces
+
+- `/etc/sourceos/storage/` — operator-visible storage and mount policy declarations
+- `/usr/libexec/sourceos/` — helper entry points for classification, import, and policy rendering
+- `/usr/lib/systemd/system/` — optional service or one-shot unit files if later justified
+- `/usr/share/doc/sourceos/storage/` — operator guidance and recovery notes
+
+## Recommended package split for later realization
+
+- `sourceos-storage-policy`
+- `sourceos-storage-import`
+- `sourceos-storage-systemd` (optional)
+- `sourceos-storage-udisks` (optional)
+- `sourceos-storage-selinux` (optional)
+- `sourceos-storage-apparmor` (optional)
+
+## Rule of thumb
+
+- keep foreign-volume discovery and import in user space where practical
+- avoid normalizing risky foreign-filesystem write paths into the base substrate package
+- keep substrate-sensitive recovery behavior distinct from ordinary exchange workflows

--- a/docs/storage/upstream_workstreams.md
+++ b/docs/storage/upstream_workstreams.md
@@ -1,0 +1,36 @@
+# Upstream Workstreams
+
+## Workstream A — policy and classification MVP
+Deliver:
+- foreign-volume class model downstream of the merged standards surface
+- filesystem policy matrix
+- Apple dual-boot posture
+- mount-flag defaults and evidence requirements
+
+This is the default and preferred path.
+
+## Workstream B — Linux estate integration
+Deliver:
+- systemd mount and automount realization where appropriate
+- packaging notes and helper placement
+- import/export job posture
+- rootless and container exposure rules
+- later SELinux/AppArmor alignment if needed
+
+## Workstream C — dual-boot and recovery validation
+Deliver separately:
+- Apple/macOS dual-boot validation notes
+- recovery and rollback guidance
+- explicit operator flows for safe import and exchange
+
+## Workstream D — explicit read-write exception lane
+Defer until the first three workstreams are stable.
+
+This lane should handle only:
+- declared exception cases
+- evidence-bearing approvals
+- tested and documented foreign filesystem write paths
+
+## Rule of thumb
+
+If a foreign volume does not need to be mutated in place, keep the workflow read-only and copy into governed native storage instead.


### PR DESCRIPTION
## Summary

Add the first storage-specific Linux-estate tranche in `source-os`, mirroring the newly merged `docs/mesh/` pattern.

This PR adds:
- `docs/storage/README.md`
- `docs/storage/foreign_volume_linux_estate_upstream_plan.md`
- `docs/storage/foreign_filesystem_policy_matrix.md`
- `docs/storage/upstream_workstreams.md`

## Why now

The standards-side storage and mount-surface doctrine is now upstream on `main` in `SocioProphet/socioprophet-standards-storage` as `096-sourceos-storage-and-mount-surfaces.md`.

That standard establishes the substrate surface-class model, but it does not fully capture foreign-volume and cross-OS mount handling. This PR creates the downstream Linux realization tranche for that work without over-coupling it to a concrete mount implementation too early.

## Placement rule

This repository remains the Linux realization home.
Shared standards and canonical vocabulary remain upstream in `SocioProphet/socioprophet-standards-storage` and typed resources should remain outside this repo.

## Included here

- a storage-topic README establishing the split
- a Linux-estate upstream plan for foreign-volume handling
- a foreign-filesystem policy matrix covering APFS, HFS+, exFAT, foreign Linux filesystems, and boot-adjacent assets
- staged workstreams for policy, Linux estate integration, validation, and explicit RW exceptions

## Deliberate non-goals in this PR

- no mount-unit or automount template yet
- no generator or daemon design yet
- no risky foreign-filesystem write-path normalization

## Follow-on

- land the standards-side foreign-volume follow-on standard after 096
- add packaging notes and later Linux-facing templates once the policy matrix stabilizes
- add Apple dual-boot validation notes and recovery guidance
