### PR TITLE
build(source-os): add Liberty Stack verification install helper

### DIFF
--- a/build/liberty-stack/scripts/enable_liberty_stack_verify.sh
+++ b/build/liberty-stack/scripts/enable_liberty_stack_verify.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SYSTEMCTL_BIN="${SYSTEMCTL_BIN:-systemctl}"
+SYSTEMD_DIR="${SYSTEMD_DIR:-/etc/systemd/system}"
+
+if [[ ! -f "$SYSTEMD_DIR/liberty-stack-verify.service" ]]; then
+  echo "missing unit: $SYSTEMD_DIR/liberty-stack-verify.service" >&2
+  exit 2
+fi
+
+if [[ ! -f "$SYSTEMD_DIR/liberty-stack-verify.timer" ]]; then
+  echo "missing timer: $SYSTEMD_DIR/liberty-stack-verify.timer" >&2
+  exit 2
+fi
+
+"$SYSTEMCTL_BIN" daemon-reload
+"$SYSTEMCTL_BIN" enable --now liberty-stack-verify.timer
+"$SYSTEMCTL_BIN" status --no-pager liberty-stack-verify.timer || true

--- a/build/liberty-stack/scripts/install_liberty_stack_verify.sh
+++ b/build/liberty-stack/scripts/install_liberty_stack_verify.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PREFIX="${1:-/usr/local}"
+SYSTEMD_DIR="${SYSTEMD_DIR:-/etc/systemd/system}"
+ETC_DIR="${ETC_DIR:-/etc/source-os/liberty-stack}"
+
+install -d "$PREFIX/lib/source-os/liberty-stack"
+install -d "$SYSTEMD_DIR"
+install -d "$ETC_DIR"
+
+install -m 0755 build/liberty-stack/scripts/liberty_stack_verify.sh "$PREFIX/lib/source-os/liberty-stack/liberty_stack_verify.sh"
+install -m 0644 build/liberty-stack/restic.env.example "$ETC_DIR/restic.env.example"
+install -m 0644 build/liberty-stack/systemd/liberty-stack-verify.service "$SYSTEMD_DIR/liberty-stack-verify.service"
+install -m 0644 build/liberty-stack/systemd/liberty-stack-verify.timer "$SYSTEMD_DIR/liberty-stack-verify.timer"
+
+echo "Installed Liberty Stack verification assets to:"
+echo "  script: $PREFIX/lib/source-os/liberty-stack/liberty_stack_verify.sh"
+echo "  env example: $ETC_DIR/restic.env.example"
+echo "  units: $SYSTEMD_DIR/liberty-stack-verify.service + .timer"
+echo "Next: copy restic.env.example to restic.env, set values, then enable the timer."


### PR DESCRIPTION
## Summary

Add the first install helper for the Liberty Stack verification assets already landed in `source-os`.

## What this PR adds

- `build/liberty-stack/scripts/install_liberty_stack_verify.sh`

## Why

The Linux substrate lane already has:
- a verification script
- an example Restic environment file
- a systemd service
- a systemd timer

What it did not yet have was a single helper that installs those assets into host-facing paths.

This PR closes that gap with a thin install helper that:
- installs the verification script under a host prefix
- installs the example environment file under `/etc/source-os/liberty-stack`
- installs the service and timer into the systemd unit directory

## Deliberate limits

This is still a thin substrate slice.
It does not yet add package-manager integration, preset files, or a broader host profile.

Those should follow after this helper shape is accepted.
