### PR TITLE
linux-dev/workstation-v0: GNOME baseline (gsettings + wiring)

### DIFF
--- a/profiles/linux-dev/workstation-v0/doctor.sh
+++ b/profiles/linux-dev/workstation-v0/doctor.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 fail=0
 
 info(){ printf "INFO: %s\n" "$*" >&2; }
+warn(){ printf "WARN: %s\n" "$*" >&2; }
 err(){ printf "ERROR: %s\n" "$*" >&2; fail=1; }
 
 have(){ command -v "$1" >/dev/null 2>&1; }
@@ -15,6 +16,16 @@ check(){
   else
     err "missing: $bin"
   fi
+}
+
+gnome_detect(){
+  if [[ "${XDG_CURRENT_DESKTOP:-}" == *GNOME* ]]; then
+    return 0
+  fi
+  if [[ "${DESKTOP_SESSION:-}" == *gnome* ]]; then
+    return 0
+  fi
+  return 1
 }
 
 main(){
@@ -69,6 +80,17 @@ main(){
   check rclone
   check mc
   check rsync
+
+  # GNOME baseline signals (non-fatal)
+  if gnome_detect; then
+    if have gsettings; then
+      info "gnome: detected; gsettings present"
+    else
+      warn "gnome: detected but gsettings missing"
+    fi
+  else
+    info "gnome: not detected (ok)"
+  fi
 
   if [[ $fail -ne 0 ]]; then
     info "doctor: FAIL"

--- a/profiles/linux-dev/workstation-v0/gnome/README.md
+++ b/profiles/linux-dev/workstation-v0/gnome/README.md
@@ -1,0 +1,29 @@
+# GNOME baseline (workstation-v0)
+
+This directory contains a **minimal GNOME baseline** for the workstation profile.
+
+Principles:
+
+- Behavioral configuration via **GSettings** (no GNOME core forks).
+- Conservative defaults that are stable across GNOME upgrades.
+- Avoid invasive keybinding rewrites until we pin and validate a full shortcut map.
+
+## Apply
+
+```bash
+./apply.sh
+```
+
+## Current baseline (v0)
+
+- Enable window buttons: close/minimize/maximize (left)
+- Touchpad: tap-to-click + natural scrolling
+- Show battery percentage
+- Show weekday in clock
+- Enable dynamic workspaces
+
+Future work:
+
+- Extension pinset (dash-to-dock, appindicator, etc.)
+- Albert hotkey binding (Super+Space) once the command surface is confirmed
+- Wayland-safe keyboard remap lane (keyd/xremap) in addition to Kinto

--- a/profiles/linux-dev/workstation-v0/gnome/apply.sh
+++ b/profiles/linux-dev/workstation-v0/gnome/apply.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Apply minimal GNOME baseline settings for workstation-v0.
+# Safe to run repeatedly.
+
+info(){ printf "INFO: %s\n" "$*" >&2; }
+warn(){ printf "WARN: %s\n" "$*" >&2; }
+
+have(){ command -v "$1" >/dev/null 2>&1; }
+
+is_gnome(){
+  # Best-effort detection.
+  if [[ "${XDG_CURRENT_DESKTOP:-}" == *GNOME* ]]; then
+    return 0
+  fi
+  if [[ "${DESKTOP_SESSION:-}" == *gnome* ]]; then
+    return 0
+  fi
+  return 1
+}
+
+set_if(){
+  # set_if <schema> <key> <value...>
+  local schema=$1; shift
+  local key=$1; shift
+  local value=("$@")
+  gsettings set "$schema" "$key" "${value[*]}" >/dev/null
+}
+
+main(){
+  if ! have gsettings; then
+    warn "gsettings not found; skipping GNOME baseline"
+    exit 0
+  fi
+
+  if ! is_gnome; then
+    warn "GNOME not detected (XDG_CURRENT_DESKTOP=${XDG_CURRENT_DESKTOP:-unset}); skipping"
+    exit 0
+  fi
+
+  info "Applying GNOME baseline settings"
+
+  # Window buttons (mac-like: left)
+  set_if org.gnome.desktop.wm.preferences button-layout "close,minimize,maximize:"
+
+  # Touchpad
+  set_if org.gnome.desktop.peripherals.touchpad tap-to-click true
+  set_if org.gnome.desktop.peripherals.touchpad natural-scroll true
+
+  # UI indicators
+  set_if org.gnome.desktop.interface show-battery-percentage true
+  set_if org.gnome.desktop.interface clock-show-weekday true
+
+  # Workspaces
+  set_if org.gnome.mutter dynamic-workspaces true
+
+  info "GNOME baseline applied"
+}
+
+main "$@"

--- a/profiles/linux-dev/workstation-v0/install.sh
+++ b/profiles/linux-dev/workstation-v0/install.sh
@@ -6,6 +6,7 @@ MANIFEST="$PROFILE_DIR/manifest.yaml"
 
 err(){ printf "ERROR: %s\n" "$*" >&2; }
 info(){ printf "INFO: %s\n" "$*" >&2; }
+warn(){ printf "WARN: %s\n" "$*" >&2; }
 
 have(){ command -v "$1" >/dev/null 2>&1; }
 
@@ -56,11 +57,22 @@ install_shell_spine(){
   info "Enable by sourcing it from your shell rc (zshrc/bashrc)."
 }
 
+apply_gnome_baseline(){
+  local script="$PROFILE_DIR/gnome/apply.sh"
+  if [[ -x "$script" ]]; then
+    info "Applying GNOME baseline (best-effort)"
+    "$script" || warn "GNOME baseline apply failed (non-fatal)"
+  else
+    warn "GNOME baseline script not found: $script"
+  fi
+}
+
 main(){
   [[ -f "$MANIFEST" ]] || { err "manifest missing: $MANIFEST"; exit 2; }
   install_system
   install_user
   install_shell_spine
+  apply_gnome_baseline
   info "installed workstation-v0 (linux-dev)"
   info "next: ./doctor.sh"
 }


### PR DESCRIPTION
Adds a minimal GNOME baseline for Workstation v0 and wires it into the linux-dev profile installer.

Changes:
- `profiles/linux-dev/workstation-v0/gnome/apply.sh` applies conservative GSettings defaults (buttons, touchpad, battery %, weekday clock, dynamic workspaces).
- Installer calls GNOME apply script best-effort (non-fatal).
- Doctor reports GNOME detection and gsettings availability.

This keeps GNOME customization behavioral and avoids core forks; extension pinset will be layered next.
