### PR TITLE
runtime: bootstrap sourceos-shell Linux module, desktop entry, and service scaffolds

### DIFF
--- a/docs/sourceos-shell-integration.md
+++ b/docs/sourceos-shell-integration.md
@@ -1,0 +1,26 @@
+# sourceos-shell Linux realization note
+
+`sourceos-shell` is the primary product/runtime repository for the SourceOS shell application stack.
+
+This repository, `source-os`, carries the Linux realization surfaces required to run that shell on Linux hosts and images.
+
+## What belongs here
+
+- desktop entries
+- systemd user or host services
+- Nix/NixOS modules
+- profile wiring
+- machine-level integration hooks
+
+## What does not belong here
+
+- shared schema canon
+- product/runtime UI code
+- ad hoc control-plane semantics
+
+## Upstream relationship
+
+- `SourceOS-Linux/sourceos-shell` — product/runtime
+- `SourceOS-Linux/sourceos-spec` — shared contracts
+- `SociOS-Linux/source-os` — Linux realization
+- `SociOS-Linux/albert` — temporary launcher bridge only

--- a/linux/desktop/sourceos-shell.desktop
+++ b/linux/desktop/sourceos-shell.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Type=Application
+Name=SourceOS Shell
+Comment=SourceOS shell runtime scaffold
+Exec=/opt/sourceos-shell/bin/sourceos-shell
+Terminal=false
+Categories=Development;Utility;
+StartupNotify=true

--- a/linux/systemd/sourceos-pdf-secure.service
+++ b/linux/systemd/sourceos-pdf-secure.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=SourceOS PDF secure service
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/opt/sourceos-shell/bin/sourceos-pdf-secure
+Restart=on-failure
+RestartSec=2s
+
+[Install]
+WantedBy=multi-user.target

--- a/linux/systemd/sourceos-router.service
+++ b/linux/systemd/sourceos-router.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=SourceOS Router bridge
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/opt/sourceos-shell/bin/sourceos-router
+Restart=on-failure
+RestartSec=2s
+
+[Install]
+WantedBy=multi-user.target

--- a/linux/systemd/sourceos-shell.service
+++ b/linux/systemd/sourceos-shell.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=SourceOS Shell runtime
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/opt/sourceos-shell/bin/sourceos-shell
+Restart=on-failure
+RestartSec=2s
+
+[Install]
+WantedBy=multi-user.target

--- a/modules/nixos/sourceos-shell/default.nix
+++ b/modules/nixos/sourceos-shell/default.nix
@@ -1,0 +1,77 @@
+{ config, lib, pkgs, ... }:
+let
+  cfg = config.sourceos.shell;
+in
+{
+  options.sourceos.shell = {
+    enable = lib.mkEnableOption "SourceOS shell Linux realization";
+
+    packageRoot = lib.mkOption {
+      type = lib.types.str;
+      default = "/opt/sourceos-shell";
+      description = "Filesystem root where the sourceos-shell runtime is expected to be installed.";
+    };
+
+    shellPort = lib.mkOption {
+      type = lib.types.port;
+      default = 4173;
+      description = "Default local port for the sourceos-shell web runtime.";
+    };
+
+    routerPort = lib.mkOption {
+      type = lib.types.port;
+      default = 7071;
+      description = "Local port for the sourceos-shell router bridge service.";
+    };
+
+    pdfSecurePort = lib.mkOption {
+      type = lib.types.port;
+      default = 7072;
+      description = "Local port for the sourceos-shell pdf-secure service.";
+    };
+
+    docdPort = lib.mkOption {
+      type = lib.types.port;
+      default = 7073;
+      description = "Local port for the sourceos-shell derive/docd service.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.etc."sourceos-shell/README".text = ''
+      SourceOS shell Linux realization scaffold.
+      packageRoot=${cfg.packageRoot}
+      shellPort=${toString cfg.shellPort}
+      routerPort=${toString cfg.routerPort}
+      pdfSecurePort=${toString cfg.pdfSecurePort}
+      docdPort=${toString cfg.docdPort}
+    '';
+
+    systemd.services.sourceos-shell = {
+      description = "SourceOS shell runtime scaffold";
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        Type = "simple";
+        ExecStart = "${pkgs.coreutils}/bin/echo sourceos-shell runtime placeholder root=${cfg.packageRoot} port=${toString cfg.shellPort}";
+      };
+    };
+
+    systemd.services.sourceos-router = {
+      description = "SourceOS shell router scaffold";
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        Type = "simple";
+        ExecStart = "${pkgs.coreutils}/bin/echo sourceos-router placeholder port=${toString cfg.routerPort}";
+      };
+    };
+
+    systemd.services.sourceos-pdf-secure = {
+      description = "SourceOS shell pdf-secure scaffold";
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        Type = "simple";
+        ExecStart = "${pkgs.coreutils}/bin/echo sourceos-pdf-secure placeholder port=${toString cfg.pdfSecurePort}";
+      };
+    };
+  };
+}

--- a/profiles/linux-dev/sourceos-shell.nix
+++ b/profiles/linux-dev/sourceos-shell.nix
@@ -1,0 +1,14 @@
+{ ... }:
+{
+  imports = [
+    ../../modules/nixos/sourceos-shell/default.nix
+  ];
+
+  sourceos.shell = {
+    enable = true;
+    shellPort = 4173;
+    routerPort = 7071;
+    pdfSecurePort = 7072;
+    docdPort = 7073;
+  };
+}


### PR DESCRIPTION
## Summary

Bootstrap the Linux realization layer for the planned `sourceos-shell` product/runtime.

This PR adds:

- Linux placement documentation
- a first `sourceos.shell` Nix module scaffold
- a `linux-dev` shell profile scaffold
- desktop entry scaffold
- systemd unit scaffolds for shell, router, and pdf-secure

## Added files

### Docs
- `docs/sourceos-shell-integration.md`

### Nix modules / profiles
- `modules/nixos/sourceos-shell/default.nix`
- `profiles/linux-dev/sourceos-shell.nix`

### Desktop / runtime assets
- `linux/desktop/sourceos-shell.desktop`
- `linux/systemd/sourceos-shell.service`
- `linux/systemd/sourceos-router.service`
- `linux/systemd/sourceos-pdf-secure.service`

## Why

`source-os` is the Linux realization home. This PR keeps Linux-specific packaging and integration here while leaving product/runtime code to the planned `SourceOS-Linux/sourceos-shell` repo and shared contracts to `SourceOS-Linux/sourceos-spec`.

## Notes

This is intentionally a bootstrap cut. The services point at placeholder runtime paths under `/opt/sourceos-shell` and the Nix module uses safe placeholder commands. Follow-on PRs can replace these with the actual shell packages and add tests/profile wiring as the product repo becomes available.

## Follow-on

- create `SourceOS-Linux/sourceos-shell`
- wire real packages into the Nix module
- add integration tests for service graph and desktop entry
- land the Albert temporary bridge work tracked separately
