### PR TITLE
linux-dev/workstation-v0: GNOME extension pinset (dash-to-dock + appindicator)

### DIFF
--- a/profiles/linux-dev/workstation-v0/doctor.sh
+++ b/profiles/linux-dev/workstation-v0/doctor.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 fail=0
 
 info(){ printf "INFO: %s\n" "$*" >&2; }
+warn(){ printf "WARN: %s\n" "$*" >&2; }
 err(){ printf "ERROR: %s\n" "$*" >&2; fail=1; }
 
 have(){ command -v "$1" >/dev/null 2>&1; }
@@ -15,6 +16,16 @@ check(){
   else
     err "missing: $bin"
   fi
+}
+
+gnome_detect(){
+  if [[ "${XDG_CURRENT_DESKTOP:-}" == *GNOME* ]]; then
+    return 0
+  fi
+  if [[ "${DESKTOP_SESSION:-}" == *gnome* ]]; then
+    return 0
+  fi
+  return 1
 }
 
 main(){
@@ -69,6 +80,17 @@ main(){
   check rclone
   check mc
   check rsync
+
+  # GNOME baseline signals (non-fatal)
+  if gnome_detect; then
+    if have gsettings; then
+      info "gnome: detected; gsettings present"
+    else
+      warn "gnome: detected but gsettings missing"
+    fi
+  else
+    info "gnome: not detected (ok)"
+  fi
 
   if [[ $fail -ne 0 ]]; then
     info "doctor: FAIL"

--- a/profiles/linux-dev/workstation-v0/doctor.sh
+++ b/profiles/linux-dev/workstation-v0/doctor.sh
@@ -19,13 +19,23 @@ check(){
 }
 
 gnome_detect(){
-  if [[ "${XDG_CURRENT_DESKTOP:-}" == *GNOME* ]]; then
-    return 0
-  fi
-  if [[ "${DESKTOP_SESSION:-}" == *gnome* ]]; then
-    return 0
-  fi
+  [[ "${XDG_CURRENT_DESKTOP:-}" == *GNOME* ]] && return 0
+  [[ "${DESKTOP_SESSION:-}" == *gnome* ]] && return 0
   return 1
+}
+
+check_gnome_extension(){
+  local uuid=$1
+  if ! have gnome-extensions; then
+    warn "gnome-extensions missing; cannot validate extension: $uuid"
+    return 0
+  fi
+
+  if gnome-extensions list | grep -qx "$uuid"; then
+    info "gnome-ext present: $uuid"
+  else
+    warn "gnome-ext missing: $uuid"
+  fi
 }
 
 main(){
@@ -88,6 +98,11 @@ main(){
     else
       warn "gnome: detected but gsettings missing"
     fi
+
+    # Extension pinset (non-fatal)
+    check_gnome_extension 'dash-to-dock@micxgx.gmail.com'
+    check_gnome_extension 'appindicatorsupport@rgcjonas.gmail.com'
+
   else
     info "gnome: not detected (ok)"
   fi

--- a/profiles/linux-dev/workstation-v0/gnome/README.md
+++ b/profiles/linux-dev/workstation-v0/gnome/README.md
@@ -1,0 +1,29 @@
+# GNOME baseline (workstation-v0)
+
+This directory contains a **minimal GNOME baseline** for the workstation profile.
+
+Principles:
+
+- Behavioral configuration via **GSettings** (no GNOME core forks).
+- Conservative defaults that are stable across GNOME upgrades.
+- Avoid invasive keybinding rewrites until we pin and validate a full shortcut map.
+
+## Apply
+
+```bash
+./apply.sh
+```
+
+## Current baseline (v0)
+
+- Enable window buttons: close/minimize/maximize (left)
+- Touchpad: tap-to-click + natural scrolling
+- Show battery percentage
+- Show weekday in clock
+- Enable dynamic workspaces
+
+Future work:
+
+- Extension pinset (dash-to-dock, appindicator, etc.)
+- Albert hotkey binding (Super+Space) once the command surface is confirmed
+- Wayland-safe keyboard remap lane (keyd/xremap) in addition to Kinto

--- a/profiles/linux-dev/workstation-v0/gnome/apply.sh
+++ b/profiles/linux-dev/workstation-v0/gnome/apply.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Apply minimal GNOME baseline settings for workstation-v0.
+# Safe to run repeatedly.
+
+info(){ printf "INFO: %s\n" "$*" >&2; }
+warn(){ printf "WARN: %s\n" "$*" >&2; }
+
+have(){ command -v "$1" >/dev/null 2>&1; }
+
+is_gnome(){
+  # Best-effort detection.
+  if [[ "${XDG_CURRENT_DESKTOP:-}" == *GNOME* ]]; then
+    return 0
+  fi
+  if [[ "${DESKTOP_SESSION:-}" == *gnome* ]]; then
+    return 0
+  fi
+  return 1
+}
+
+set_if(){
+  # set_if <schema> <key> <value...>
+  local schema=$1; shift
+  local key=$1; shift
+  local value=("$@")
+  gsettings set "$schema" "$key" "${value[*]}" >/dev/null
+}
+
+main(){
+  if ! have gsettings; then
+    warn "gsettings not found; skipping GNOME baseline"
+    exit 0
+  fi
+
+  if ! is_gnome; then
+    warn "GNOME not detected (XDG_CURRENT_DESKTOP=${XDG_CURRENT_DESKTOP:-unset}); skipping"
+    exit 0
+  fi
+
+  info "Applying GNOME baseline settings"
+
+  # Window buttons (mac-like: left)
+  set_if org.gnome.desktop.wm.preferences button-layout "close,minimize,maximize:"
+
+  # Touchpad
+  set_if org.gnome.desktop.peripherals.touchpad tap-to-click true
+  set_if org.gnome.desktop.peripherals.touchpad natural-scroll true
+
+  # UI indicators
+  set_if org.gnome.desktop.interface show-battery-percentage true
+  set_if org.gnome.desktop.interface clock-show-weekday true
+
+  # Workspaces
+  set_if org.gnome.mutter dynamic-workspaces true
+
+  info "GNOME baseline applied"
+}
+
+main "$@"

--- a/profiles/linux-dev/workstation-v0/gnome/extensions-install.sh
+++ b/profiles/linux-dev/workstation-v0/gnome/extensions-install.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install and enable GNOME extension pinset for workstation-v0 (linux-dev).
+# - Prefers distro packages (Fedora) for stability.
+# - Uses gnome-extensions for enable.
+# - Safe to run repeatedly.
+
+info(){ printf "INFO: %s\n" "$*" >&2; }
+warn(){ printf "WARN: %s\n" "$*" >&2; }
+err(){ printf "ERROR: %s\n" "$*" >&2; }
+
+have(){ command -v "$1" >/dev/null 2>&1; }
+
+is_gnome(){
+  [[ "${XDG_CURRENT_DESKTOP:-}" == *GNOME* ]] && return 0
+  [[ "${DESKTOP_SESSION:-}" == *gnome* ]] && return 0
+  return 1
+}
+
+os_id(){
+  if [[ -r /etc/os-release ]]; then
+    . /etc/os-release
+    echo "${ID:-linux}"
+  else
+    echo "linux"
+  fi
+}
+
+install_pkgs_fedora(){
+  # Prefer rpm-ostree when available.
+  if have rpm-ostree; then
+    info "Installing GNOME extension RPMs via rpm-ostree (may require reboot)"
+    sudo rpm-ostree install gnome-shell-extension-dash-to-dock gnome-shell-extension-appindicator || true
+    return
+  fi
+  if have dnf; then
+    info "Installing GNOME extension RPMs via dnf"
+    sudo dnf install -y gnome-shell-extension-dash-to-dock gnome-shell-extension-appindicator || true
+    return
+  fi
+  warn "No rpm-ostree/dnf found; skipping package install"
+}
+
+enable_ext(){
+  local uuid=$1
+  if ! have gnome-extensions; then
+    warn "gnome-extensions not found; cannot enable $uuid"
+    return 0
+  fi
+
+  # Only enable if present.
+  if gnome-extensions list | grep -qx "$uuid"; then
+    gnome-extensions enable "$uuid" || true
+    info "enabled: $uuid"
+  else
+    warn "extension not present (uuid): $uuid"
+  fi
+}
+
+apply_dash_to_dock_defaults(){
+  if ! have gsettings; then
+    warn "gsettings not found; skipping dash-to-dock defaults"
+    return 0
+  fi
+
+  # Defaults tuned for mac-like dock behavior.
+  gsettings set org.gnome.shell.extensions.dash-to-dock dock-position 'BOTTOM'
+  gsettings set org.gnome.shell.extensions.dash-to-dock autohide true
+  gsettings set org.gnome.shell.extensions.dash-to-dock intellihide true
+  gsettings set org.gnome.shell.extensions.dash-to-dock dash-max-icon-size 36
+}
+
+main(){
+  if ! is_gnome; then
+    warn "GNOME not detected; skipping extension pinset"
+    exit 0
+  fi
+
+  local id
+  id="$(os_id)"
+  if [[ "$id" == "fedora" ]]; then
+    install_pkgs_fedora
+  else
+    warn "Unsupported distro for packaged extension installs (id=$id); skipping install"
+  fi
+
+  enable_ext 'dash-to-dock@micxgx.gmail.com'
+  enable_ext 'appindicatorsupport@rgcjonas.gmail.com'
+
+  apply_dash_to_dock_defaults
+
+  info "GNOME extension pinset complete"
+  info "NOTE: You may need to log out/in (or reboot on rpm-ostree) for shell extensions to load."
+}
+
+main "$@"

--- a/profiles/linux-dev/workstation-v0/gnome/extensions.yaml
+++ b/profiles/linux-dev/workstation-v0/gnome/extensions.yaml
@@ -1,0 +1,21 @@
+# GNOME extension pinset for workstation-v0 (linux-dev)
+#
+# This file is documentation-first in v0; the installer script uses the same IDs.
+
+extensions:
+  - id: dash-to-dock@micxgx.gmail.com
+    packages:
+      fedora:
+        - gnome-shell-extension-dash-to-dock
+    defaults:
+      schema: org.gnome.shell.extensions.dash-to-dock
+      settings:
+        dock-position: "BOTTOM"
+        autohide: true
+        intellihide: true
+        dash-max-icon-size: 36
+
+  - id: appindicatorsupport@rgcjonas.gmail.com
+    packages:
+      fedora:
+        - gnome-shell-extension-appindicator

--- a/profiles/linux-dev/workstation-v0/install.sh
+++ b/profiles/linux-dev/workstation-v0/install.sh
@@ -6,6 +6,7 @@ MANIFEST="$PROFILE_DIR/manifest.yaml"
 
 err(){ printf "ERROR: %s\n" "$*" >&2; }
 info(){ printf "INFO: %s\n" "$*" >&2; }
+warn(){ printf "WARN: %s\n" "$*" >&2; }
 
 have(){ command -v "$1" >/dev/null 2>&1; }
 
@@ -56,11 +57,22 @@ install_shell_spine(){
   info "Enable by sourcing it from your shell rc (zshrc/bashrc)."
 }
 
+apply_gnome_baseline(){
+  local script="$PROFILE_DIR/gnome/apply.sh"
+  if [[ -x "$script" ]]; then
+    info "Applying GNOME baseline (best-effort)"
+    "$script" || warn "GNOME baseline apply failed (non-fatal)"
+  else
+    warn "GNOME baseline script not found: $script"
+  fi
+}
+
 main(){
   [[ -f "$MANIFEST" ]] || { err "manifest missing: $MANIFEST"; exit 2; }
   install_system
   install_user
   install_shell_spine
+  apply_gnome_baseline
   info "installed workstation-v0 (linux-dev)"
   info "next: ./doctor.sh"
 }

--- a/profiles/linux-dev/workstation-v0/install.sh
+++ b/profiles/linux-dev/workstation-v0/install.sh
@@ -67,12 +67,23 @@ apply_gnome_baseline(){
   fi
 }
 
+apply_gnome_extensions(){
+  local script="$PROFILE_DIR/gnome/extensions-install.sh"
+  if [[ -x "$script" ]]; then
+    info "Applying GNOME extension pinset (best-effort)"
+    "$script" || warn "GNOME extensions apply failed (non-fatal)"
+  else
+    warn "GNOME extensions installer not found: $script"
+  fi
+}
+
 main(){
   [[ -f "$MANIFEST" ]] || { err "manifest missing: $MANIFEST"; exit 2; }
   install_system
   install_user
   install_shell_spine
   apply_gnome_baseline
+  apply_gnome_extensions
   info "installed workstation-v0 (linux-dev)"
   info "next: ./doctor.sh"
 }


### PR DESCRIPTION
STACKED on PR #25 (base: feat/linux-dev-workstation-v0-gnome-baseline).

Adds a minimal GNOME extension pinset for Workstation v0 and wires it into the linux-dev installer.

Changes:
- `profiles/linux-dev/workstation-v0/gnome/extensions.yaml` documents extension UUIDs and default intent.
- `profiles/linux-dev/workstation-v0/gnome/extensions-install.sh` installs packaged extensions on Fedora (dnf/rpm-ostree), enables them, and applies dash-to-dock defaults.
- Installer calls extensions installer best-effort.
- Doctor validates extension presence when GNOME is detected.

Notes:
- Uses distro-packaged extensions for stability. On rpm-ostree, reboot/logout may be required.
