### PR TITLE
linux-dev/workstation-v0: Albert hotkey binding (Super+Space)

### DIFF
--- a/profiles/linux-dev/workstation-v0/doctor.sh
+++ b/profiles/linux-dev/workstation-v0/doctor.sh
@@ -95,6 +95,19 @@ main(){
   if gnome_detect; then
     if have gsettings; then
       info "gnome: detected; gsettings present"
+
+      # best-effort visibility of albert hotkey binding
+      local base="/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/"
+      local custom0="${base}custom0/"
+      local bindings
+      bindings=$(gsettings get org.gnome.settings-daemon.plugins.media-keys custom-keybindings || true)
+      info "gnome: custom-keybindings = ${bindings}"
+      local hk
+      hk=$(gsettings get org.gnome.settings-daemon.plugins.media-keys.custom-keybinding:${custom0} binding 2>/dev/null || true)
+      if [[ -n "$hk" ]]; then
+        info "gnome: albert binding = ${hk}"
+      fi
+
     else
       warn "gnome: detected but gsettings missing"
     fi

--- a/profiles/linux-dev/workstation-v0/gnome/albert-hotkey.sh
+++ b/profiles/linux-dev/workstation-v0/gnome/albert-hotkey.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Configure a GNOME custom keybinding for Albert.
+# We bind Super+Space to `albert toggle` by default.
+# We also avoid collision with GNOME input-source switching by moving that to Alt+Shift.
+
+info(){ printf "INFO: %s\n" "$*" >&2; }
+warn(){ printf "WARN: %s\n" "$*" >&2; }
+
+have(){ command -v "$1" >/dev/null 2>&1; }
+
+is_gnome(){
+  [[ "${XDG_CURRENT_DESKTOP:-}" == *GNOME* ]] && return 0
+  [[ "${DESKTOP_SESSION:-}" == *gnome* ]] && return 0
+  return 1
+}
+
+main(){
+  if ! have gsettings; then
+    warn "gsettings missing; cannot set hotkey"
+    exit 0
+  fi
+
+  if ! is_gnome; then
+    warn "GNOME not detected; skipping hotkey"
+    exit 0
+  fi
+
+  # Move input source switching away from Super+Space (macOS uses Cmd+Space for search).
+  # GNOME typically uses: org.gnome.desktop.wm.keybindings switch-input-source / switch-input-source-backward
+  gsettings set org.gnome.desktop.wm.keybindings switch-input-source "['<Alt>Shift_L']" || true
+  gsettings set org.gnome.desktop.wm.keybindings switch-input-source-backward "['<Alt>Shift_R']" || true
+
+  # Add a custom keybinding for Albert.
+  # Path style: /org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom0/
+  local base="/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/"
+  local custom0="${base}custom0/"
+
+  gsettings set org.gnome.settings-daemon.plugins.media-keys custom-keybindings "['${custom0}']" || true
+
+  gsettings set org.gnome.settings-daemon.plugins.media-keys.custom-keybinding:${custom0} name "Albert" || true
+  gsettings set org.gnome.settings-daemon.plugins.media-keys.custom-keybinding:${custom0} command "albert toggle" || true
+  gsettings set org.gnome.settings-daemon.plugins.media-keys.custom-keybinding:${custom0} binding "<Super>space" || true
+
+  info "Albert hotkey set: <Super>Space → albert toggle"
+  info "Input source switching moved to Alt+Shift (L/R)"
+}
+
+main "$@"

--- a/profiles/linux-dev/workstation-v0/install.sh
+++ b/profiles/linux-dev/workstation-v0/install.sh
@@ -77,6 +77,16 @@ apply_gnome_extensions(){
   fi
 }
 
+apply_albert_hotkey(){
+  local script="$PROFILE_DIR/gnome/albert-hotkey.sh"
+  if [[ -x "$script" ]]; then
+    info "Setting Albert hotkey (best-effort)"
+    "$script" || warn "Albert hotkey setup failed (non-fatal)"
+  else
+    warn "Albert hotkey script not found: $script"
+  fi
+}
+
 main(){
   [[ -f "$MANIFEST" ]] || { err "manifest missing: $MANIFEST"; exit 2; }
   install_system
@@ -84,6 +94,7 @@ main(){
   install_shell_spine
   apply_gnome_baseline
   apply_gnome_extensions
+  apply_albert_hotkey
   info "installed workstation-v0 (linux-dev)"
   info "next: ./doctor.sh"
 }


### PR DESCRIPTION
Adds GNOME hotkey wiring for Albert as part of the Workstation v0 linux-dev profile.

Changes:
- `profiles/linux-dev/workstation-v0/gnome/albert-hotkey.sh`:
  - binds `<Super>space` to `albert toggle`
  - moves GNOME input source switching to Alt+Shift to avoid conflict with macOS-like search muscle memory
- Installer calls the hotkey script best-effort (non-fatal).
- Doctor reports current custom keybinding list and the configured binding.

Notes:
- Albert supports RPC commands via its CLI when an instance is already running (e.g. `albert toggle`), and has an internal hotkey default Ctrl+Space, but the workstation profile standardizes the GNOME-level muscle memory.
