### PR TITLE
linux-dev/workstation-v0: Albert autostart entry (GNOME)

### DIFF
--- a/profiles/linux-dev/workstation-v0/doctor.sh
+++ b/profiles/linux-dev/workstation-v0/doctor.sh
@@ -38,6 +38,10 @@ check_gnome_extension(){
   fi
 }
 
+autostart_path(){
+  echo "${XDG_CONFIG_HOME:-$HOME/.config}/autostart/albert.desktop"
+}
+
 main(){
   info "doctor: linux-dev/workstation-v0"
 
@@ -115,6 +119,15 @@ main(){
     # Extension pinset (non-fatal)
     check_gnome_extension 'dash-to-dock@micxgx.gmail.com'
     check_gnome_extension 'appindicatorsupport@rgcjonas.gmail.com'
+
+    # Autostart (non-fatal)
+    local ap
+    ap="$(autostart_path)"
+    if [[ -f "$ap" ]]; then
+      info "gnome: albert autostart present: $ap"
+    else
+      warn "gnome: albert autostart missing: $ap"
+    fi
 
   else
     info "gnome: not detected (ok)"

--- a/profiles/linux-dev/workstation-v0/gnome/albert-autostart.sh
+++ b/profiles/linux-dev/workstation-v0/gnome/albert-autostart.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install GNOME autostart entry for Albert.
+# Purpose: ensure Albert is running so `albert toggle` hotkey works reliably.
+
+info(){ printf "INFO: %s\n" "$*" >&2; }
+warn(){ printf "WARN: %s\n" "$*" >&2; }
+
+have(){ command -v "$1" >/dev/null 2>&1; }
+
+is_gnome(){
+  [[ "${XDG_CURRENT_DESKTOP:-}" == *GNOME* ]] && return 0
+  [[ "${DESKTOP_SESSION:-}" == *gnome* ]] && return 0
+  return 1
+}
+
+main(){
+  if ! is_gnome; then
+    warn "GNOME not detected; skipping autostart"
+    exit 0
+  fi
+
+  local autostart_dir
+  autostart_dir="${XDG_CONFIG_HOME:-$HOME/.config}/autostart"
+  mkdir -p "$autostart_dir"
+
+  local desktop_file="$autostart_dir/albert.desktop"
+
+  cat > "$desktop_file" <<'EOF'
+[Desktop Entry]
+Type=Application
+Name=Albert
+Comment=Albert launcher
+Exec=albert
+Terminal=false
+X-GNOME-Autostart-enabled=true
+X-GNOME-Autostart-Delay=1
+OnlyShowIn=GNOME;
+EOF
+
+  info "installed autostart entry: $desktop_file"
+
+  if ! have albert; then
+    warn "albert not found on PATH; autostart entry created anyway"
+  fi
+}
+
+main "$@"

--- a/profiles/linux-dev/workstation-v0/install.sh
+++ b/profiles/linux-dev/workstation-v0/install.sh
@@ -87,6 +87,16 @@ apply_albert_hotkey(){
   fi
 }
 
+apply_albert_autostart(){
+  local script="$PROFILE_DIR/gnome/albert-autostart.sh"
+  if [[ -x "$script" ]]; then
+    info "Installing Albert autostart entry (best-effort)"
+    "$script" || warn "Albert autostart setup failed (non-fatal)"
+  else
+    warn "Albert autostart script not found: $script"
+  fi
+}
+
 main(){
   [[ -f "$MANIFEST" ]] || { err "manifest missing: $MANIFEST"; exit 2; }
   install_system
@@ -95,6 +105,7 @@ main(){
   apply_gnome_baseline
   apply_gnome_extensions
   apply_albert_hotkey
+  apply_albert_autostart
   info "installed workstation-v0 (linux-dev)"
   info "next: ./doctor.sh"
 }


### PR DESCRIPTION
STACKED on PR #28 (base: feat/linux-dev-workstation-v0-albert-hotkey).

Ensures Albert is started automatically on GNOME so the workstation hotkey (`albert toggle`) works reliably.

Changes:
- Adds `profiles/linux-dev/workstation-v0/gnome/albert-autostart.sh` which writes `~/.config/autostart/albert.desktop`.
- Wires autostart setup into the profile installer (best-effort / non-fatal).
- Extends doctor to report whether the autostart file exists.

Notes:
- GNOME-scoped (OnlyShowIn=GNOME).
- This PR intentionally does not install Albert itself; next PR will add installation.
