### PR TITLE
build(source-os): add exit host lane and control-plane bootstrap ops

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -52,6 +52,12 @@
           specialArgs = { inherit self; };
           modules = [ ./hosts/stable-x86_64/default.nix ];
         };
+
+        exit-x86_64 = lib.nixosSystem {
+          system = "x86_64-linux";
+          specialArgs = { inherit self; };
+          modules = [ ./hosts/exit-x86_64/default.nix ];
+        };
       };
 
       checks = forAllSystems (system:
@@ -75,6 +81,13 @@
             if system == "x86_64-linux"
             then import ./tests/stable-x86_64-contract.nix { inherit pkgs; }
             else pkgs.runCommand "stable-x86_64-smoke-skip" {} ''
+              mkdir -p $out
+            '';
+
+          exit-x86_64-smoke =
+            if system == "x86_64-linux"
+            then import ./tests/exit-x86_64-contract.nix { inherit pkgs; }
+            else pkgs.runCommand "exit-x86_64-smoke-skip" {} ''
               mkdir -p $out
             '';
 

--- a/hosts/exit-x86_64/default.nix
+++ b/hosts/exit-x86_64/default.nix
@@ -1,0 +1,23 @@
+{ self, pkgs, ... }:
+{
+  imports = [
+    ../../profiles/linux-stable/default.nix
+  ];
+
+  networking.hostName = "exit-x86_64";
+
+  sourceos.build = {
+    role = "exit-x86_64";
+    channel = "stable";
+  };
+
+  sourceos.mesh = {
+    role = "exit";
+    runtime = {
+      enable = true;
+      meshdPackage = self.packages.${pkgs.system}.meshd;
+      linkdPackage = self.packages.${pkgs.system}.meshd-linkd;
+      exitdPackage = self.packages.${pkgs.system}.meshd-exitd;
+    };
+  };
+}

--- a/packages/mesh/meshd-exitd.nix
+++ b/packages/mesh/meshd-exitd.nix
@@ -1,7 +1,7 @@
-{ writeShellApplication, coreutils }:
+{ writeShellApplication, python3, systemd, coreutils, nftables }:
 writeShellApplication {
   name = "meshd-exitd";
-  runtimeInputs = [ coreutils ];
+  runtimeInputs = [ python3 systemd coreutils nftables ];
   text = ''
     set -euo pipefail
 
@@ -34,6 +34,93 @@ writeShellApplication {
       exit 2
     fi
 
-    exec sleep infinity
+    exec python3 - "$CONFIG" "$NFT" <<'PY'
+import os
+import signal
+import subprocess
+import sys
+import time
+from typing import Any
+
+config_path = sys.argv[1]
+nft_path = sys.argv[2]
+stop = False
+
+
+def _stop(*_args):
+    global stop
+    stop = True
+
+
+def parse_value(raw: str) -> Any:
+    raw = raw.strip()
+    if raw.startswith('"') and raw.endswith('"'):
+        return raw[1:-1]
+    if raw.lower() in {"true", "false"}:
+        return raw.lower() == "true"
+    try:
+        return int(raw)
+    except ValueError:
+        return raw
+
+
+def load_toml_like(path: str) -> dict[str, dict[str, Any]]:
+    data: dict[str, dict[str, Any]] = {}
+    section = "root"
+    data[section] = {}
+    with open(path, "r", encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if line.startswith("[") and line.endswith("]"):
+                section = line[1:-1].strip()
+                data.setdefault(section, {})
+                continue
+            if "=" not in line:
+                continue
+            key, value = line.split("=", 1)
+            data.setdefault(section, {})[key.strip()] = parse_value(value)
+    return data
+
+
+def validate_nft(path: str) -> None:
+    subprocess.run(["nft", "-c", "-f", path], check=True)
+
+
+signal.signal(signal.SIGTERM, _stop)
+signal.signal(signal.SIGINT, _stop)
+
+config = load_toml_like(config_path)
+exit_cfg = config.get("exit", {})
+routing = config.get("routing", {})
+
+if not exit_cfg.get("allow_full_tunnel", False):
+    raise SystemExit("meshd-exitd: full-tunnel exit role is not enabled in the config")
+
+validate_nft(nft_path)
+
+status = f"meshd-exitd active (table={routing.get('exit_route_table')}, fwmark={routing.get('exit_fwmark')})"
+if os.environ.get("NOTIFY_SOCKET"):
+    subprocess.run(["systemd-notify", "--ready", f"--status={status}"], check=False)
+
+last_nft_mtime = os.path.getmtime(nft_path)
+last_cfg_mtime = os.path.getmtime(config_path)
+
+while not stop:
+    time.sleep(5)
+    cfg_mtime = os.path.getmtime(config_path)
+    nft_mtime = os.path.getmtime(nft_path)
+    if cfg_mtime != last_cfg_mtime or nft_mtime != last_nft_mtime:
+        config = load_toml_like(config_path)
+        exit_cfg = config.get("exit", {})
+        if not exit_cfg.get("allow_full_tunnel", False):
+            raise SystemExit("meshd-exitd: full-tunnel exit role was disabled during reload")
+        validate_nft(nft_path)
+        last_cfg_mtime = cfg_mtime
+        last_nft_mtime = nft_mtime
+        if os.environ.get("NOTIFY_SOCKET"):
+            subprocess.run(["systemd-notify", f"--status=meshd-exitd revalidated ({nft_path})"], check=False)
+PY
   '';
 }

--- a/packages/mesh/meshd-linkd.nix
+++ b/packages/mesh/meshd-linkd.nix
@@ -37,6 +37,7 @@ writeShellApplication {
     mkdir -p "$(dirname "$RPC_PATH")"
 
     exec python3 - "$RPC_PATH" "$CONTROL_PATH" <<'PY'
+import json
 import os
 import select
 import signal
@@ -44,22 +45,88 @@ import socket
 import subprocess
 import sys
 import time
+from typing import Any
 
 rpc_path = sys.argv[1]
 control_path = sys.argv[2]
 stop = False
 
+
 def _stop(*_args):
     global stop
     stop = True
+
+
+def recv_json(conn: socket.socket) -> dict[str, Any]:
+    data = b""
+    while True:
+        chunk = conn.recv(65536)
+        if not chunk:
+            break
+        data += chunk
+        if b"\n" in chunk:
+            break
+    if not data:
+        return {"ok": False, "error": "empty response"}
+    return json.loads(data.decode("utf-8").strip())
+
+
+def send_json(conn: socket.socket, payload: dict[str, Any]) -> None:
+    conn.sendall((json.dumps(payload, sort_keys=True) + "\n").encode("utf-8"))
+
+
+def call_control(payload: dict[str, Any]) -> dict[str, Any]:
+    conn = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    conn.settimeout(5)
+    conn.connect(control_path)
+    with conn:
+        send_json(conn, payload)
+        return recv_json(conn)
+
+
+def read_request(conn: socket.socket) -> dict[str, Any]:
+    data = b""
+    while True:
+        chunk = conn.recv(65536)
+        if not chunk:
+            break
+        data += chunk
+        if b"\n" in chunk:
+            break
+    if not data:
+        return {"op": "ping"}
+    text = data.decode("utf-8").strip()
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        return {"op": "ping", "raw": text}
+
+
+def register() -> dict[str, Any]:
+    return call_control({
+        "op": "register-helper",
+        "helper": "linkd",
+        "socket": rpc_path,
+        "capabilities": ["get-link-plan", "get-manifest", "status"],
+    })
+
 
 signal.signal(signal.SIGTERM, _stop)
 signal.signal(signal.SIGINT, _stop)
 
 for _ in range(30):
     if os.path.exists(control_path):
-        break
+        try:
+            ping = call_control({"op": "ping"})
+            if ping.get("ok"):
+                break
+        except Exception:
+            pass
     time.sleep(1)
+else:
+    raise SystemExit("meshd-linkd: control socket never became ready")
+
+registration = register()
 
 try:
     os.unlink(rpc_path)
@@ -68,20 +135,46 @@ except FileNotFoundError:
 
 srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
 srv.bind(rpc_path)
-srv.listen(8)
+srv.listen(16)
 
 if os.environ.get("NOTIFY_SOCKET"):
     subprocess.run([
         "systemd-notify",
         "--ready",
-        f"--status=meshd-linkd bootstrap active ({rpc_path})"
+        f"--status=meshd-linkd active ({rpc_path})"
     ], check=False)
 
 while not stop:
     ready, _, _ = select.select([srv], [], [], 1.0)
-    if srv in ready:
-        conn, _ = srv.accept()
-        conn.close()
+    if srv not in ready:
+        continue
+    conn, _ = srv.accept()
+    with conn:
+        req = read_request(conn)
+        op = req.get("op", "ping")
+        if op == "ping":
+            send_json(conn, {"ok": True, "service": "meshd-linkd", "socket": rpc_path})
+            continue
+        if op == "status":
+            status = call_control({"op": "status"})
+            send_json(conn, {
+                "ok": True,
+                "service": "meshd-linkd",
+                "registration": registration,
+                "upstream": status,
+            })
+            continue
+        if op == "get-link-plan":
+            send_json(conn, call_control({"op": "render-link-plan"}))
+            continue
+        if op == "get-manifest":
+            send_json(conn, call_control({"op": "get-manifest"}))
+            continue
+        if op == "refresh-registration":
+            registration = register()
+            send_json(conn, {"ok": True, "service": "meshd-linkd", "registration": registration})
+            continue
+        send_json(conn, {"ok": False, "service": "meshd-linkd", "error": f"unsupported op: {op}"})
 
 srv.close()
 try:

--- a/packages/mesh/meshd.nix
+++ b/packages/mesh/meshd.nix
@@ -42,24 +42,105 @@ writeShellApplication {
     mkdir -p "$(dirname "$SOCKET_PATH")"
 
     exec python3 - "$CONFIG" "$SOCKET_PATH" <<'PY'
+import json
 import os
 import select
 import signal
 import socket
 import subprocess
 import sys
+import time
+from typing import Any
 
 config_path = sys.argv[1]
 socket_path = sys.argv[2]
-
 stop = False
+
 
 def _stop(*_args):
     global stop
     stop = True
 
+
+def parse_value(raw: str) -> Any:
+    raw = raw.strip()
+    if raw.startswith('"') and raw.endswith('"'):
+        return raw[1:-1]
+    if raw.lower() in {"true", "false"}:
+        return raw.lower() == "true"
+    try:
+        return int(raw)
+    except ValueError:
+        return raw
+
+
+def load_toml_like(path: str) -> dict[str, dict[str, Any]]:
+    data: dict[str, dict[str, Any]] = {}
+    section = "root"
+    data[section] = {}
+    with open(path, "r", encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if line.startswith("[") and line.endswith("]"):
+                section = line[1:-1].strip()
+                data.setdefault(section, {})
+                continue
+            if "=" not in line:
+                continue
+            key, value = line.split("=", 1)
+            data.setdefault(section, {})[key.strip()] = parse_value(value)
+    return data
+
+
+def manifest_payload(path: str | None) -> dict[str, Any]:
+    if not path:
+        return {"exists": False, "path": None, "payload": None}
+    if not os.path.exists(path):
+        return {"exists": False, "path": path, "payload": None}
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            return {"exists": True, "path": path, "payload": json.load(handle)}
+    except Exception as exc:
+        return {"exists": True, "path": path, "payload": None, "error": str(exc)}
+
+
+def response(conn: socket.socket, payload: dict[str, Any]) -> None:
+    conn.sendall((json.dumps(payload, sort_keys=True) + "\n").encode("utf-8"))
+
+
+def read_request(conn: socket.socket) -> dict[str, Any]:
+    data = b""
+    while True:
+        chunk = conn.recv(65536)
+        if not chunk:
+            break
+        data += chunk
+        if b"\n" in chunk:
+            break
+    if not data:
+        return {"op": "ping"}
+    text = data.decode("utf-8").strip()
+    if not text:
+        return {"op": "ping"}
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        return {"op": "ping", "raw": text}
+
+
 signal.signal(signal.SIGTERM, _stop)
 signal.signal(signal.SIGINT, _stop)
+
+config = load_toml_like(config_path)
+identity = config.get("identity", {})
+paths = config.get("paths", {})
+routing = config.get("routing", {})
+state: dict[str, Any] = {
+    "helpers": {},
+    "started_at": int(time.time()),
+}
 
 try:
     os.unlink(socket_path)
@@ -68,20 +149,71 @@ except FileNotFoundError:
 
 srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
 srv.bind(socket_path)
-srv.listen(8)
+srv.listen(16)
 
 if os.environ.get("NOTIFY_SOCKET"):
     subprocess.run([
         "systemd-notify",
         "--ready",
-        f"--status=meshd bootstrap active ({socket_path})"
+        f"--status=meshd control plane active ({socket_path})"
     ], check=False)
 
 while not stop:
     ready, _, _ = select.select([srv], [], [], 1.0)
-    if srv in ready:
-        conn, _ = srv.accept()
-        conn.close()
+    if srv not in ready:
+        continue
+    conn, _ = srv.accept()
+    with conn:
+        req = read_request(conn)
+        op = req.get("op", "ping")
+
+        if op == "ping":
+            response(conn, {"ok": True, "service": "meshd", "socket": socket_path})
+            continue
+
+        if op == "status":
+            response(conn, {
+                "ok": True,
+                "service": "meshd",
+                "identity": identity,
+                "paths": paths,
+                "routing": routing,
+                "helpers": state["helpers"],
+                "started_at": state["started_at"],
+            })
+            continue
+
+        if op == "get-manifest":
+            response(conn, {"ok": True, "service": "meshd", **manifest_payload(paths.get("manifest"))})
+            continue
+
+        if op == "render-link-plan":
+            response(conn, {
+                "ok": True,
+                "service": "meshd",
+                "plan": {
+                    "interface": identity.get("interface"),
+                    "role": identity.get("role"),
+                    "manager": identity.get("manager"),
+                    "routing": routing,
+                    "manifest": paths.get("manifest"),
+                    "control_socket": paths.get("control_socket"),
+                    "link_socket": paths.get("link_socket"),
+                },
+            })
+            continue
+
+        if op == "register-helper":
+            helper = req.get("helper", "unknown")
+            state["helpers"][helper] = {
+                "socket": req.get("socket"),
+                "capabilities": req.get("capabilities", []),
+                "registered_at": int(time.time()),
+            }
+            response(conn, {"ok": True, "service": "meshd", "registered": helper})
+            continue
+
+        response(conn, {"ok": False, "service": "meshd", "error": f"unsupported op: {op}"})
 
 srv.close()
 try:

--- a/tests/exit-x86_64-contract.nix
+++ b/tests/exit-x86_64-contract.nix
@@ -1,0 +1,13 @@
+{ pkgs ? import <nixpkgs> {} }:
+pkgs.runCommand "exit-x86_64-contract" {
+  nativeBuildInputs = [ pkgs.gnugrep ];
+} ''
+  test -f ${../hosts/exit-x86_64/default.nix}
+  grep -q '../../profiles/linux-stable/default.nix' ${../hosts/exit-x86_64/default.nix}
+  grep -q 'networking.hostName = "exit-x86_64"' ${../hosts/exit-x86_64/default.nix}
+  grep -q 'sourceos.mesh = {' ${../hosts/exit-x86_64/default.nix}
+  grep -q 'role = "exit"' ${../hosts/exit-x86_64/default.nix}
+  grep -q 'exitdPackage = self.packages.${pkgs.system}.meshd-exitd;' ${../hosts/exit-x86_64/default.nix}
+  mkdir -p $out
+  echo validated > $out/result.txt
+''

--- a/tests/mesh-host-runtime-contract.nix
+++ b/tests/mesh-host-runtime-contract.nix
@@ -5,12 +5,16 @@ pkgs.runCommand "mesh-host-runtime-contract" {
   grep -q 'specialArgs = { inherit self; };' ${../flake.nix}
   grep -q '{ self, pkgs, ... }:' ${../hosts/canary-x86_64/default.nix}
   grep -q '{ self, pkgs, ... }:' ${../hosts/stable-x86_64/default.nix}
+  grep -q '{ self, pkgs, ... }:' ${../hosts/exit-x86_64/default.nix}
   grep -q 'sourceos.mesh.runtime = {' ${../hosts/canary-x86_64/default.nix}
   grep -q 'sourceos.mesh.runtime = {' ${../hosts/stable-x86_64/default.nix}
+  grep -q 'runtime = {' ${../hosts/exit-x86_64/default.nix}
   grep -q 'meshdPackage = self.packages.${pkgs.system}.meshd;' ${../hosts/canary-x86_64/default.nix}
   grep -q 'linkdPackage = self.packages.${pkgs.system}.meshd-linkd;' ${../hosts/canary-x86_64/default.nix}
   grep -q 'meshdPackage = self.packages.${pkgs.system}.meshd;' ${../hosts/stable-x86_64/default.nix}
   grep -q 'linkdPackage = self.packages.${pkgs.system}.meshd-linkd;' ${../hosts/stable-x86_64/default.nix}
+  grep -q 'role = "exit"' ${../hosts/exit-x86_64/default.nix}
+  grep -q 'exitdPackage = self.packages.${pkgs.system}.meshd-exitd;' ${../hosts/exit-x86_64/default.nix}
   mkdir -p $out
   echo validated > $out/result.txt
 ''

--- a/tests/mesh-package-contract.nix
+++ b/tests/mesh-package-contract.nix
@@ -9,9 +9,13 @@ pkgs.runCommand "mesh-package-contract" {
   grep -q 'meshd = pkgs.callPackage ./packages/mesh/meshd.nix' ${../flake.nix}
   grep -q 'meshd-linkd = pkgs.callPackage ./packages/mesh/meshd-linkd.nix' ${../flake.nix}
   grep -q 'meshd-exitd = pkgs.callPackage ./packages/mesh/meshd-exitd.nix' ${../flake.nix}
+  grep -q 'register-helper' ${../packages/mesh/meshd.nix}
+  grep -q 'render-link-plan' ${../packages/mesh/meshd.nix}
+  grep -q 'refresh-registration' ${../packages/mesh/meshd-linkd.nix}
+  grep -q 'validate_nft' ${../packages/mesh/meshd-exitd.nix}
   grep -q 'systemd-notify' ${../packages/mesh/meshd.nix}
   grep -q 'systemd-notify' ${../packages/mesh/meshd-linkd.nix}
-  grep -q 'sleep infinity' ${../packages/mesh/meshd-exitd.nix}
+  grep -q 'systemd-notify' ${../packages/mesh/meshd-exitd.nix}
   mkdir -p $out
   echo validated > $out/result.txt
 ''


### PR DESCRIPTION
## Summary

Implement the next tranche after the merged daemon-package and host-default work.

This PR adds:
- substantive bootstrap control-plane behavior to `meshd`
- helper registration and plan proxying in `meshd-linkd`
- nftables validation and revalidation loop in `meshd-exitd`
- a dedicated `exit-x86_64` host lane
- flake wiring for the new exit host and contract coverage
- updated package/runtime contracts aligned to the new daemon behavior

## What this changes

The daemon packages no longer just hold space for future implementations.

### `meshd`
Now provides a simple JSON-over-UNIX control socket that can:
- answer `ping`
- return `status`
- return the manifest payload
- register helpers
- render a simple link plan

### `meshd-linkd`
Now:
- waits for the control socket
- registers itself with `meshd`
- serves its own RPC socket
- proxies `status`, `get-link-plan`, and `get-manifest`

### `meshd-exitd`
Now:
- parses the generated exit config
- requires full-tunnel exit enablement
- validates the nftables file with `nft -c -f`
- revalidates config and nft policy when they change

### Topology
Adds the first dedicated exit host lane:
- `hosts/exit-x86_64/default.nix`
- stable-channel host
- `sourceos.mesh.role = "exit"`
- runtime defaults wired to `meshd`, `meshd-linkd`, and `meshd-exitd`

## Scope honesty

This is still bootstrap control-plane behavior, not the final sovereign mesh control plane.
But it is materially more real than the previous placeholder package surfaces and gives us an actual exit lane to compose and test.

## Follow-up still needed

Tracked in #15:
- replace the bootstrap JSON-over-UNIX control loop with richer control-plane state and policy handling
- add confinement
- freeze support matrix
- add deeper evaluation/integration tests beyond grep-style contracts
