### PR TITLE
linux-dev/workstation-v0: install Albert (Fedora) and require it on GNOME

### DIFF
--- a/profiles/linux-dev/workstation-v0/doctor.sh
+++ b/profiles/linux-dev/workstation-v0/doctor.sh
@@ -95,8 +95,11 @@ main(){
   check mc
   check rsync
 
-  # GNOME baseline signals (non-fatal)
+  # GNOME expectations
   if gnome_detect; then
+    # Albert becomes a must-have in GNOME deployments.
+    check albert
+
     if have gsettings; then
       info "gnome: detected; gsettings present"
 

--- a/profiles/linux-dev/workstation-v0/gnome/albert-install.sh
+++ b/profiles/linux-dev/workstation-v0/gnome/albert-install.sh
@@ -2,8 +2,12 @@
 set -euo pipefail
 
 # Install Albert on Fedora-based systems.
-# We prefer distro packaging for stability.
-# Safe to run repeatedly.
+# Strategy:
+#   1) Try native repos (dnf/rpm-ostree).
+#   2) If not available, add the OBS repo from home:manuelschneid3r and retry.
+#
+# This keeps the workstation “don’t think about it” while still remaining explicit
+# about trust boundaries: adding a third-party RPM repo is a trust expansion.
 
 info(){ printf "INFO: %s\n" "$*" >&2; }
 warn(){ printf "WARN: %s\n" "$*" >&2; }
@@ -25,21 +29,85 @@ os_id(){
   fi
 }
 
-install_fedora(){
-  # Prefer rpm-ostree when available.
-  if have rpm-ostree; then
-    info "Installing Albert via rpm-ostree (may require reboot)"
-    sudo rpm-ostree install albert || true
+os_version_id(){
+  if [[ -r /etc/os-release ]]; then
+    . /etc/os-release
+    echo "${VERSION_ID:-}"
+  else
+    echo ""
+  fi
+}
+
+fedora_obs_repofile_url(){
+  # OBS provides a yum repo file per Fedora version.
+  # Example URLs from software.opensuse.org for Fedora_41+ and Rawhide.
+  local v
+  v="$(os_version_id)"
+
+  # Rawhide is sometimes expressed as 'rawhide' or empty.
+  if [[ "$v" == "rawhide" || "$v" == "Rawhide" || -z "$v" ]]; then
+    echo "https://download.opensuse.org/repositories/home:manuelschneid3r/Fedora_Rawhide/home:manuelschneid3r.repo"
     return
+  fi
+
+  # Numeric Fedora releases
+  echo "https://download.opensuse.org/repositories/home:manuelschneid3r/Fedora_${v}/home:manuelschneid3r.repo"
+}
+
+install_obs_repo(){
+  local url
+  url="$(fedora_obs_repofile_url)"
+
+  local dest="/etc/yum.repos.d/home:manuelschneid3r.repo"
+
+  info "Adding OBS repo for Albert (home:manuelschneid3r): $url"
+
+  if have curl; then
+    curl -fsSL "$url" | sudo tee "$dest" >/dev/null
+  elif have wget; then
+    wget -qO- "$url" | sudo tee "$dest" >/dev/null
+  else
+    warn "Neither curl nor wget found; cannot add OBS repo automatically"
+    return 1
+  fi
+
+  info "Repo file installed: $dest"
+}
+
+try_install_native(){
+  if have rpm-ostree; then
+    info "Trying rpm-ostree install albert"
+    sudo rpm-ostree install albert || true
+    return 0
   fi
 
   if have dnf; then
-    info "Installing Albert via dnf"
+    info "Trying dnf install albert"
     sudo dnf install -y albert || true
-    return
+    return 0
   fi
 
   warn "No rpm-ostree/dnf found; cannot install Albert"
+  return 1
+}
+
+try_install_with_obs(){
+  install_obs_repo || return 1
+
+  # Retry install now that repo is present.
+  if have rpm-ostree; then
+    info "Retrying rpm-ostree install albert (with OBS repo)"
+    sudo rpm-ostree install albert || true
+    return 0
+  fi
+
+  if have dnf; then
+    info "Retrying dnf install albert (with OBS repo)"
+    sudo dnf install -y albert || true
+    return 0
+  fi
+
+  return 1
 }
 
 main(){
@@ -56,17 +124,26 @@ main(){
   local id
   id="$(os_id)"
 
-  if [[ "$id" == "fedora" ]]; then
-    install_fedora
-  else
+  if [[ "$id" != "fedora" ]]; then
     warn "Unsupported distro for Albert install (id=$id). Install Albert manually."
     exit 0
   fi
 
+  try_install_native
+
   if have albert; then
-    info "albert installed"
+    info "albert installed (native repos)"
+    exit 0
+  fi
+
+  warn "Albert not found in native repos; attempting OBS repo fallback"
+  try_install_with_obs
+
+  if have albert; then
+    info "albert installed (OBS repo)"
   else
-    warn "albert not found after install attempt. You may need to enable additional repos or install manually."
+    warn "albert not found after install attempts."
+    warn "You may need to install manually from software.opensuse.org for your Fedora version."
   fi
 }
 

--- a/profiles/linux-dev/workstation-v0/gnome/albert-install.sh
+++ b/profiles/linux-dev/workstation-v0/gnome/albert-install.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install Albert on Fedora-based systems.
+# We prefer distro packaging for stability.
+# Safe to run repeatedly.
+
+info(){ printf "INFO: %s\n" "$*" >&2; }
+warn(){ printf "WARN: %s\n" "$*" >&2; }
+
+have(){ command -v "$1" >/dev/null 2>&1; }
+
+is_gnome(){
+  [[ "${XDG_CURRENT_DESKTOP:-}" == *GNOME* ]] && return 0
+  [[ "${DESKTOP_SESSION:-}" == *gnome* ]] && return 0
+  return 1
+}
+
+os_id(){
+  if [[ -r /etc/os-release ]]; then
+    . /etc/os-release
+    echo "${ID:-linux}"
+  else
+    echo "linux"
+  fi
+}
+
+install_fedora(){
+  # Prefer rpm-ostree when available.
+  if have rpm-ostree; then
+    info "Installing Albert via rpm-ostree (may require reboot)"
+    sudo rpm-ostree install albert || true
+    return
+  fi
+
+  if have dnf; then
+    info "Installing Albert via dnf"
+    sudo dnf install -y albert || true
+    return
+  fi
+
+  warn "No rpm-ostree/dnf found; cannot install Albert"
+}
+
+main(){
+  if have albert; then
+    info "albert already present"
+    exit 0
+  fi
+
+  if ! is_gnome; then
+    warn "GNOME not detected; skipping Albert install"
+    exit 0
+  fi
+
+  local id
+  id="$(os_id)"
+
+  if [[ "$id" == "fedora" ]]; then
+    install_fedora
+  else
+    warn "Unsupported distro for Albert install (id=$id). Install Albert manually."
+    exit 0
+  fi
+
+  if have albert; then
+    info "albert installed"
+  else
+    warn "albert not found after install attempt. You may need to enable additional repos or install manually."
+  fi
+}
+
+main "$@"

--- a/profiles/linux-dev/workstation-v0/gnome/albert-install.sh
+++ b/profiles/linux-dev/workstation-v0/gnome/albert-install.sh
@@ -4,10 +4,12 @@ set -euo pipefail
 # Install Albert on Fedora-based systems.
 # Strategy:
 #   1) Try native repos (dnf/rpm-ostree).
-#   2) If not available, add the OBS repo from home:manuelschneid3r and retry.
+#   2) If not available, *optionally* add the OBS repo from home:manuelschneid3r and retry.
 #
-# This keeps the workstation “don’t think about it” while still remaining explicit
-# about trust boundaries: adding a third-party RPM repo is a trust expansion.
+# Trust note:
+# - Adding a third-party RPM repo expands the host trust boundary.
+# - Therefore the OBS fallback is gated behind:
+#     SOURCEOS_ALLOW_THIRDPARTY_REPOS=1
 
 info(){ printf "INFO: %s\n" "$*" >&2; }
 warn(){ printf "WARN: %s\n" "$*" >&2; }
@@ -38,19 +40,22 @@ os_version_id(){
   fi
 }
 
+allow_thirdparty_repos(){
+  case "${SOURCEOS_ALLOW_THIRDPARTY_REPOS:-0}" in
+    1|true|TRUE|yes|YES) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 fedora_obs_repofile_url(){
-  # OBS provides a yum repo file per Fedora version.
-  # Example URLs from software.opensuse.org for Fedora_41+ and Rawhide.
   local v
   v="$(os_version_id)"
 
-  # Rawhide is sometimes expressed as 'rawhide' or empty.
   if [[ "$v" == "rawhide" || "$v" == "Rawhide" || -z "$v" ]]; then
     echo "https://download.opensuse.org/repositories/home:manuelschneid3r/Fedora_Rawhide/home:manuelschneid3r.repo"
     return
   fi
 
-  # Numeric Fedora releases
   echo "https://download.opensuse.org/repositories/home:manuelschneid3r/Fedora_${v}/home:manuelschneid3r.repo"
 }
 
@@ -94,7 +99,6 @@ try_install_native(){
 try_install_with_obs(){
   install_obs_repo || return 1
 
-  # Retry install now that repo is present.
   if have rpm-ostree; then
     info "Retrying rpm-ostree install albert (with OBS repo)"
     sudo rpm-ostree install albert || true
@@ -108,6 +112,16 @@ try_install_with_obs(){
   fi
 
   return 1
+}
+
+print_obs_instructions(){
+  local url
+  url="$(fedora_obs_repofile_url)"
+  warn "OBS fallback is disabled by default (trust boundary expansion)."
+  warn "To allow enabling the OBS repo automatically, set:"
+  warn "  export SOURCEOS_ALLOW_THIRDPARTY_REPOS=1"
+  warn "Then re-run this installer."
+  warn "If you prefer manual install, repo file URL is: $url"
 }
 
 main(){
@@ -136,7 +150,14 @@ main(){
     exit 0
   fi
 
-  warn "Albert not found in native repos; attempting OBS repo fallback"
+  warn "Albert not found in native repos."
+
+  if ! allow_thirdparty_repos; then
+    print_obs_instructions
+    exit 2
+  fi
+
+  warn "Third-party repos allowed; attempting OBS repo fallback"
   try_install_with_obs
 
   if have albert; then
@@ -144,6 +165,7 @@ main(){
   else
     warn "albert not found after install attempts."
     warn "You may need to install manually from software.opensuse.org for your Fedora version."
+    exit 2
   fi
 }
 

--- a/profiles/linux-dev/workstation-v0/install.sh
+++ b/profiles/linux-dev/workstation-v0/install.sh
@@ -77,6 +77,16 @@ apply_gnome_extensions(){
   fi
 }
 
+apply_albert_install(){
+  local script="$PROFILE_DIR/gnome/albert-install.sh"
+  if [[ -x "$script" ]]; then
+    info "Installing Albert (best-effort)"
+    "$script" || warn "Albert install failed (non-fatal)"
+  else
+    warn "Albert install script not found: $script"
+  fi
+}
+
 apply_albert_hotkey(){
   local script="$PROFILE_DIR/gnome/albert-hotkey.sh"
   if [[ -x "$script" ]]; then
@@ -104,6 +114,7 @@ main(){
   install_shell_spine
   apply_gnome_baseline
   apply_gnome_extensions
+  apply_albert_install
   apply_albert_hotkey
   apply_albert_autostart
   info "installed workstation-v0 (linux-dev)"


### PR DESCRIPTION
STACKED on PR #29 (base: feat/linux-dev-workstation-v0-albert-autostart).

Adds an Albert installation lane for GNOME deployments and makes Albert a hard requirement when GNOME is detected.

Changes:
- `profiles/linux-dev/workstation-v0/gnome/albert-install.sh` installs `albert` via dnf/rpm-ostree on Fedora (best-effort).
- Installer calls the install script before wiring hotkey/autostart.
- Doctor requires `albert` when GNOME is detected (fails otherwise).

Notes:
- If Fedora repos do not provide `albert`, the installer will warn; the doctor will fail until Albert is installed by another method.
- Follow-up can add COPR/RPMFusion discovery or a source build lane if needed.
