### PR TITLE
linux-dev/workstation-v0: install SourceOS helper CLI for Albert integration

### DIFF
--- a/profiles/linux-dev/workstation-v0/bin/install-sourceos-cli.sh
+++ b/profiles/linux-dev/workstation-v0/bin/install-sourceos-cli.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install the profile-local `sourceos` helper CLI to user scope.
+# Target: ~/.local/bin/sourceos
+
+PROFILE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SRC="$PROFILE_DIR/bin/sourceos"
+DEST_DIR="${HOME}/.local/bin"
+DEST="$DEST_DIR/sourceos"
+
+info(){ printf "INFO: %s\n" "$*" >&2; }
+warn(){ printf "WARN: %s\n" "$*" >&2; }
+err(){ printf "ERROR: %s\n" "$*" >&2; }
+
+main(){
+  [[ -x "$SRC" ]] || { err "sourceos helper missing: $SRC"; exit 2; }
+
+  mkdir -p "$DEST_DIR"
+  cp -f "$SRC" "$DEST"
+  chmod +x "$DEST"
+
+  info "installed: $DEST"
+
+  if [[ ":$PATH:" != *":$DEST_DIR:"* ]]; then
+    warn "~/.local/bin is not on PATH. Add one line to your shell rc:"
+    warn "  export PATH=\"$DEST_DIR:\$PATH\""
+  fi
+}
+
+main "$@"

--- a/profiles/linux-dev/workstation-v0/bin/sourceos
+++ b/profiles/linux-dev/workstation-v0/bin/sourceos
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# SourceOS workstation helper (linux-dev/workstation-v0)
+# This is a small, dependency-light command surface intended to be callable from Albert.
+
+PROFILE_DIR_DEFAULT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PROFILE_DIR="${SOURCEOS_PROFILE_DIR:-$PROFILE_DIR_DEFAULT}"
+
+err(){ printf "ERROR: %s\n" "$*" >&2; }
+info(){ printf "INFO: %s\n" "$*" >&2; }
+
+usage(){
+  cat <<EOF
+sourceos (workstation helper)
+
+Usage:
+  sourceos doctor
+  sourceos profile apply
+  sourceos profile path
+
+Env:
+  SOURCEOS_PROFILE_DIR   Override profile directory (default: $PROFILE_DIR_DEFAULT)
+EOF
+}
+
+run_doctor(){
+  local doc="$PROFILE_DIR/doctor.sh"
+  [[ -x "$doc" ]] || { err "doctor not found: $doc"; exit 2; }
+  exec "$doc"
+}
+
+run_apply(){
+  local inst="$PROFILE_DIR/install.sh"
+  [[ -x "$inst" ]] || { err "installer not found: $inst"; exit 2; }
+  exec "$inst"
+}
+
+profile_path(){
+  echo "$PROFILE_DIR"
+}
+
+main(){
+  local cmd=${1:-}
+  case "$cmd" in
+    -h|--help|help|"")
+      usage
+      ;;
+    doctor)
+      run_doctor
+      ;;
+    profile)
+      shift
+      local sub=${1:-}
+      case "$sub" in
+        apply)
+          run_apply
+          ;;
+        path)
+          profile_path
+          ;;
+        *)
+          err "unknown profile subcommand: $sub"
+          usage
+          exit 2
+          ;;
+      esac
+      ;;
+    *)
+      err "unknown command: $cmd"
+      usage
+      exit 2
+      ;;
+  esac
+}
+
+main "$@"

--- a/profiles/linux-dev/workstation-v0/doctor.sh
+++ b/profiles/linux-dev/workstation-v0/doctor.sh
@@ -63,6 +63,9 @@ main(){
   # USER expectations
   check brew
 
+  # SourceOS helper (needed for Albert SourceOS plugin actions)
+  check sourceos
+
   # Core CLI must-haves
   check fzf
   check atuin

--- a/profiles/linux-dev/workstation-v0/install.sh
+++ b/profiles/linux-dev/workstation-v0/install.sh
@@ -57,6 +57,16 @@ install_shell_spine(){
   info "Enable by sourcing it from your shell rc (zshrc/bashrc)."
 }
 
+install_sourceos_cli(){
+  local script="$PROFILE_DIR/bin/install-sourceos-cli.sh"
+  if [[ -x "$script" ]]; then
+    info "Installing SourceOS helper CLI to ~/.local/bin"
+    "$script" || warn "sourceos CLI install failed (non-fatal)"
+  else
+    warn "sourceos CLI installer not found: $script"
+  fi
+}
+
 apply_gnome_baseline(){
   local script="$PROFILE_DIR/gnome/apply.sh"
   if [[ -x "$script" ]]; then
@@ -112,6 +122,7 @@ main(){
   install_system
   install_user
   install_shell_spine
+  install_sourceos_cli
   apply_gnome_baseline
   apply_gnome_extensions
   apply_albert_install


### PR DESCRIPTION
STACKED on PR #31 (base: feat/linux-dev-workstation-v0-albert-install).

Adds a profile-local `sourceos` helper CLI and installs it into `~/.local/bin` so the Albert SourceOS plugin has a stable command surface.

Changes:
- `profiles/linux-dev/workstation-v0/bin/sourceos` (dependency-light CLI: `doctor`, `profile apply`, `profile path`)
- `profiles/linux-dev/workstation-v0/bin/install-sourceos-cli.sh` installs the helper to `~/.local/bin/sourceos`
- `install.sh` wires the CLI install step
- `doctor.sh` now requires `sourceos` on PATH

This makes the launcher integration real: Albert can invoke `sourceos doctor` and `sourceos profile apply` without needing repo-relative paths.
