### PR TITLE
linux-dev/workstation-v0: `sourceos status` JSON output + openable reports

### DIFF
--- a/profiles/linux-dev/workstation-v0/bin/sourceos
+++ b/profiles/linux-dev/workstation-v0/bin/sourceos
@@ -2,25 +2,56 @@
 set -euo pipefail
 
 # SourceOS workstation helper (linux-dev/workstation-v0)
-# This is a small, dependency-light command surface intended to be callable from Albert.
+# Dependency-light command surface intended to be callable from Albert.
 
 PROFILE_DIR_DEFAULT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PROFILE_DIR="${SOURCEOS_PROFILE_DIR:-$PROFILE_DIR_DEFAULT}"
 
 err(){ printf "ERROR: %s\n" "$*" >&2; }
 info(){ printf "INFO: %s\n" "$*" >&2; }
+warn(){ printf "WARN: %s\n" "$*" >&2; }
+
+have(){ command -v "$1" >/dev/null 2>&1; }
+
+cache_dir(){
+  echo "${XDG_CACHE_HOME:-$HOME/.cache}/sourceos"
+}
+
+json_escape(){
+  # Minimal JSON string escape (no unicode escaping)
+  local s=${1:-}
+  s=${s//\\/\\\\}
+  s=${s//"/\\"}
+  s=${s//$'\n'/\\n}
+  s=${s//$'\r'/\\r}
+  s=${s//$'\t'/\\t}
+  printf '%s' "$s"
+}
+
+open_file(){
+  local p=$1
+  if have xdg-open; then
+    xdg-open "$p" >/dev/null 2>&1 || true
+  elif have open; then
+    open "$p" >/dev/null 2>&1 || true
+  else
+    warn "no opener found (xdg-open/open); wrote: $p"
+  fi
+}
 
 usage(){
   cat <<EOF
 sourceos (workstation helper)
 
 Usage:
-  sourceos doctor
+  sourceos doctor [--open]
+  sourceos status [--json|--open|--write <path>]
   sourceos profile apply
   sourceos profile path
 
 Env:
-  SOURCEOS_PROFILE_DIR   Override profile directory (default: $PROFILE_DIR_DEFAULT)
+  SOURCEOS_PROFILE_DIR                Override profile directory (default: $PROFILE_DIR_DEFAULT)
+  SOURCEOS_ALLOW_THIRDPARTY_REPOS     See gnome/albert-install.sh
 EOF
 }
 
@@ -28,6 +59,24 @@ run_doctor(){
   local doc="$PROFILE_DIR/doctor.sh"
   [[ -x "$doc" ]] || { err "doctor not found: $doc"; exit 2; }
   exec "$doc"
+}
+
+run_doctor_open(){
+  local doc="$PROFILE_DIR/doctor.sh"
+  [[ -x "$doc" ]] || { err "doctor not found: $doc"; exit 2; }
+
+  local d
+  d="$(cache_dir)"
+  mkdir -p "$d"
+  local out="$d/doctor.txt"
+
+  set +e
+  "$doc" >"$out" 2>&1
+  local rc=$?
+  set -e
+
+  open_file "$out"
+  exit "$rc"
 }
 
 run_apply(){
@@ -40,17 +89,245 @@ profile_path(){
   echo "$PROFILE_DIR"
 }
 
+gnome_detect(){
+  [[ "${XDG_CURRENT_DESKTOP:-}" == *GNOME* ]] && return 0
+  [[ "${DESKTOP_SESSION:-}" == *gnome* ]] && return 0
+  return 1
+}
+
+autostart_path(){
+  echo "${XDG_CONFIG_HOME:-$HOME/.config}/autostart/albert.desktop"
+}
+
+check_bin(){
+  local bin=$1
+  if have "$bin"; then
+    return 0
+  fi
+  return 1
+}
+
+status_collect(){
+  # Produces global arrays:
+  #   REQUIRED_MISSING
+  #   OPTIONAL_MISSING
+  #   WARNINGS
+  REQUIRED_MISSING=()
+  OPTIONAL_MISSING=()
+  WARNINGS=()
+
+  # Required baseline (aligned with doctor.sh)
+  local required=(
+    git ssh podman toolbox wl-copy jq
+    brew sourceos
+    fzf atuin bat zoxide eza yazi gum direnv rg fd tmux
+    lazygit gh tig
+    sesh procs sd entr curlie
+    jnv gojq
+    rclone mc rsync
+  )
+
+  for b in "${required[@]}"; do
+    if ! check_bin "$b"; then
+      REQUIRED_MISSING+=("$b")
+    fi
+  done
+
+  # Optional: xclip (X11 fallback)
+  if ! check_bin xclip; then
+    OPTIONAL_MISSING+=("xclip")
+  fi
+
+  # GNOME-scoped expectations
+  if gnome_detect; then
+    if ! check_bin albert; then
+      REQUIRED_MISSING+=("albert")
+    fi
+
+    if ! check_bin gsettings; then
+      WARNINGS+=("gsettings missing")
+    fi
+
+    # Extensions presence is non-fatal.
+    if check_bin gnome-extensions; then
+      if ! gnome-extensions list 2>/dev/null | grep -qx 'dash-to-dock@micxgx.gmail.com'; then
+        WARNINGS+=("missing gnome extension: dash-to-dock@micxgx.gmail.com")
+      fi
+      if ! gnome-extensions list 2>/dev/null | grep -qx 'appindicatorsupport@rgcjonas.gmail.com'; then
+        WARNINGS+=("missing gnome extension: appindicatorsupport@rgcjonas.gmail.com")
+      fi
+    else
+      WARNINGS+=("gnome-extensions missing")
+    fi
+
+    # Autostart is non-fatal.
+    local ap
+    ap="$(autostart_path)"
+    if [[ ! -f "$ap" ]]; then
+      WARNINGS+=("albert autostart missing: $ap")
+    fi
+  fi
+}
+
+status_json(){
+  status_collect
+
+  local ok=true
+  if (( ${#REQUIRED_MISSING[@]} > 0 )); then
+    ok=false
+  fi
+
+  local profile="linux-dev/workstation-v0"
+
+  local gnome=false
+  if gnome_detect; then gnome=true; fi
+
+  # Read best-effort hotkey binding
+  local hotkey=""
+  if $gnome && have gsettings; then
+    local base="/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/"
+    local custom0="${base}custom0/"
+    hotkey=$(gsettings get org.gnome.settings-daemon.plugins.media-keys.custom-keybinding:${custom0} binding 2>/dev/null || true)
+  fi
+
+  printf '{'
+  printf '"profile":"%s"' "$(json_escape "$profile")"
+  printf ',"ok":%s' "$ok"
+  printf ',"gnome":%s' "$gnome"
+
+  printf ',"required_missing":['
+  for ((i=0;i<${#REQUIRED_MISSING[@]};i++)); do
+    [[ $i -gt 0 ]] && printf ','
+    printf '"%s"' "$(json_escape "${REQUIRED_MISSING[$i]}")"
+  done
+  printf ']'
+
+  printf ',"optional_missing":['
+  for ((i=0;i<${#OPTIONAL_MISSING[@]};i++)); do
+    [[ $i -gt 0 ]] && printf ','
+    printf '"%s"' "$(json_escape "${OPTIONAL_MISSING[$i]}")"
+  done
+  printf ']'
+
+  printf ',"warnings":['
+  for ((i=0;i<${#WARNINGS[@]};i++)); do
+    [[ $i -gt 0 ]] && printf ','
+    printf '"%s"' "$(json_escape "${WARNINGS[$i]}")"
+  done
+  printf ']'
+
+  printf ',"albert_hotkey":"%s"' "$(json_escape "$hotkey")"
+
+  printf '}'
+  printf '\n'
+
+  if [[ "$ok" == "true" ]]; then
+    return 0
+  fi
+  return 2
+}
+
+status_human(){
+  status_collect
+
+  if (( ${#REQUIRED_MISSING[@]} == 0 )); then
+    info "status: OK"
+  else
+    err "status: FAIL"
+    err "missing required: ${REQUIRED_MISSING[*]}"
+    return 2
+  fi
+
+  if (( ${#OPTIONAL_MISSING[@]} > 0 )); then
+    warn "missing optional: ${OPTIONAL_MISSING[*]}"
+  fi
+
+  if (( ${#WARNINGS[@]} > 0 )); then
+    warn "warnings:"
+    for w in "${WARNINGS[@]}"; do
+      warn "- $w"
+    done
+  fi
+
+  return 0
+}
+
+status_open(){
+  local d
+  d="$(cache_dir)"
+  mkdir -p "$d"
+  local out="$d/status.json"
+
+  set +e
+  status_json >"$out" 2>/dev/null
+  local rc=$?
+  set -e
+
+  open_file "$out"
+  exit "$rc"
+}
+
+status_write(){
+  local path=$1
+  [[ -n "$path" ]] || { err "--write requires a path"; exit 2; }
+
+  local dir
+  dir="$(dirname "$path")"
+  mkdir -p "$dir"
+
+  set +e
+  status_json >"$path" 2>/dev/null
+  local rc=$?
+  set -e
+
+  info "wrote: $path"
+  exit "$rc"
+}
+
 main(){
   local cmd=${1:-}
   case "$cmd" in
     -h|--help|help|"")
       usage
       ;;
+
     doctor)
-      run_doctor
+      shift || true
+      case "${1:-}" in
+        --open) run_doctor_open ;;
+        "") run_doctor ;;
+        *) run_doctor ;;  # forward-compat: ignore extra args for now
+      esac
       ;;
+
+    status)
+      shift || true
+      case "${1:-}" in
+        --json)
+          shift || true
+          status_json
+          ;;
+        --open)
+          shift || true
+          status_open
+          ;;
+        --write)
+          shift || true
+          status_write "${1:-}"
+          ;;
+        "")
+          status_human
+          ;;
+        *)
+          err "unknown status flag: ${1:-}"
+          usage
+          exit 2
+          ;;
+      esac
+      ;;
+
     profile)
-      shift
+      shift || true
       local sub=${1:-}
       case "$sub" in
         apply)
@@ -66,6 +343,7 @@ main(){
           ;;
       esac
       ;;
+
     *)
       err "unknown command: $cmd"
       usage


### PR DESCRIPTION
STACKED on PR #32 (base: feat/linux-dev-workstation-v0-sourceos-cli).

Adds a machine-readable and launcher-friendly status surface to the profile-local `sourceos` helper CLI.

Changes:
- `sourceos status`:
  - default: human summary
  - `--json`: JSON status report (exit 0 OK, exit 2 FAIL)
  - `--open`: writes `$XDG_CACHE_HOME/sourceos/status.json` and opens it
  - `--write <path>`: writes JSON to path
- `sourceos doctor --open`: captures doctor output to `$XDG_CACHE_HOME/sourceos/doctor.txt` and opens it

This enables Albert to surface workstation health without needing a terminal, and provides a stable JSON contract for future agentic ingestion.
