### PR TITLE
docs/flake: add workstation-v0 devShell and documentation lane

### DIFF
--- a/docs/workstation/README.md
+++ b/docs/workstation/README.md
@@ -1,0 +1,66 @@
+# Workstation (GNOME / CLI-first)
+
+This directory documents the **SourceOS Workstation Profile v0** lane.
+
+Placement rule:
+- `profiles/` contains concrete environment-specific realization surfaces.
+- This `docs/workstation/` directory explains how to apply and validate those profiles.
+
+## Primary realization
+
+- `profiles/linux-dev/workstation-v0/`
+
+## Workstation v0 goals
+
+- CLI-first developer experience with keyboard-first navigation.
+- GNOME baseline customization via GSettings and pinned extensions (no GNOME core forks).
+- Albert as an **action bus** with `sourceos` actions.
+- Local status/doctor surfaces that can be opened from the launcher.
+
+## Apply
+
+From the repo:
+
+```bash
+./profiles/linux-dev/workstation-v0/install.sh
+```
+
+## Validate
+
+```bash
+./profiles/linux-dev/workstation-v0/doctor.sh
+```
+
+Or via the installed helper:
+
+```bash
+sourceos doctor
+sourceos status --json
+```
+
+## Nix-first support
+
+This repository is Nix-native. A dev shell is provided:
+
+```bash
+nix develop .#workstation-v0
+```
+
+Notes:
+- The workstation devShell is best-effort; missing nixpkgs attrs will be reported on entry.
+- The profile installers still support non-Nix systems using `dnf/rpm-ostree` and `brew` where applicable.
+
+## Trust boundaries
+
+- Third-party RPM repo enablement (Albert OBS fallback) is gated behind:
+
+```bash
+export SOURCEOS_ALLOW_THIRDPARTY_REPOS=1
+```
+
+Without this, the installer prints explicit instructions and exits nonzero.
+
+## Related docs
+
+- `docs/repository-layout.md`
+- `docs/agentplane-integration.md`

--- a/flake.nix
+++ b/flake.nix
@@ -23,13 +23,64 @@
         });
 
       devShells = forAllSystems (system:
-        let pkgs = nixpkgs.legacyPackages.${system};
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+
+          # Workstation v0 CLI toolset (best-effort).
+          # We intentionally tolerate missing attrs to avoid breaking flake evaluation.
+          workstationV0Names = [
+            # baseline
+            "git" "jq" "nixpkgs-fmt"
+
+            # nav/shell
+            "fzf" "atuin" "bat" "zoxide" "yazi" "eza" "gum" "direnv" "tldr" "fd" "ripgrep"
+
+            # find/replace
+            "sd"
+
+            # git
+            "lazygit" "gh" "diff-so-fancy" "tig" "svu"
+
+            # process/ops
+            "tmux" "sesh" "mprocs" "procs" "lazydocker" "k9s" "btop"
+
+            # json
+            "jnv" "gojq" "fx" "jless" "jqp"
+
+            # disk
+            "dua" "dust" "kondo"
+
+            # docs/bench/watch
+            "glow" "hyperfine" "entr" "curlie"
+
+            # file motion
+            "rclone" "rsync" "minio-client"
+
+            # launcher (optional)
+            "albert"
+          ];
+
+          haveAttr = n: builtins.hasAttr n pkgs;
+          missing = lib.filter (n: !(haveAttr n)) workstationV0Names;
+          presentPkgs = lib.filter (p: p != null) (map (n: if haveAttr n then pkgs.${n} else null) workstationV0Names);
+          missingStr = lib.concatStringsSep " " missing;
         in {
           default = pkgs.mkShell {
             packages = with pkgs; [ git jq nixpkgs-fmt ];
             shellHook = ''
               echo "SourceOS Linux development shell"
               echo "See docs/repository-layout.md, docs/agentplane-integration.md, and docs/mesh/README.md"
+            '';
+          };
+
+          workstation-v0 = pkgs.mkShell {
+            packages = presentPkgs;
+            shellHook = ''
+              echo "SourceOS Workstation v0 dev shell"
+              echo "See docs/workstation/README.md"
+              if [ -n "${missingStr}" ]; then
+                echo "NOTE: missing nixpkgs attrs (not added): ${missingStr}"
+              fi
             '';
           };
         });


### PR DESCRIPTION
Adds a Nix-first developer shell for Workstation Profile v0 and documents the workstation lane.

Changes:
- `flake.nix`: adds `devShells.<system>.workstation-v0` containing a best-effort toolset aligned to the workstation manifest. Missing nixpkgs attrs are tolerated and printed.
- `docs/workstation/README.md`: documents how to apply/validate the workstation profile and how to use the new Nix devShell.

Rationale:
- `source-os` is Nix-native. This prevents our workstation work from fighting the repo’s intended mechanism, while retaining the profile installers for non-Nix hosts.

Usage:
- `nix develop .#workstation-v0`
