### PR TITLE
workstation-v0: reconcile helper CLI + albert installer into linux-dev profile

### DIFF
--- a/profiles/linux-dev/workstation-v0/bin/install-sourceos-cli.sh
+++ b/profiles/linux-dev/workstation-v0/bin/install-sourceos-cli.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install the profile-local `sourceos` helper CLI to user scope.
+# Target: ~/.local/bin/sourceos
+
+PROFILE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SRC="$PROFILE_DIR/bin/sourceos"
+DEST_DIR="${HOME}/.local/bin"
+DEST="$DEST_DIR/sourceos"
+
+info(){ printf "INFO: %s\n" "$*" >&2; }
+warn(){ printf "WARN: %s\n" "$*" >&2; }
+err(){ printf "ERROR: %s\n" "$*" >&2; }
+
+main(){
+  [[ -x "$SRC" ]] || { err "sourceos helper missing: $SRC"; exit 2; }
+
+  mkdir -p "$DEST_DIR"
+  cp -f "$SRC" "$DEST"
+  chmod +x "$DEST"
+
+  info "installed: $DEST"
+
+  if [[ ":$PATH:" != *":$DEST_DIR:"* ]]; then
+    warn "~/.local/bin is not on PATH. Add one line to your shell rc:"
+    warn "  export PATH=\"$DEST_DIR:\$PATH\""
+  fi
+}
+
+main "$@"

--- a/profiles/linux-dev/workstation-v0/bin/sourceos
+++ b/profiles/linux-dev/workstation-v0/bin/sourceos
@@ -1,0 +1,326 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# SourceOS workstation helper (linux-dev/workstation-v0)
+# Dependency-light command surface intended to be callable from Albert.
+
+PROFILE_DIR_DEFAULT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PROFILE_DIR="${SOURCEOS_PROFILE_DIR:-$PROFILE_DIR_DEFAULT}"
+
+err(){ printf "ERROR: %s\n" "$*" >&2; }
+info(){ printf "INFO: %s\n" "$*" >&2; }
+warn(){ printf "WARN: %s\n" "$*" >&2; }
+
+have(){ command -v "$1" >/dev/null 2>&1; }
+
+cache_dir(){
+  echo "${XDG_CACHE_HOME:-$HOME/.cache}/sourceos"
+}
+
+json_escape(){
+  # Minimal JSON string escape (no unicode escaping)
+  local s=${1:-}
+  s=${s//\\/\\\\}
+  s=${s//"/\\"}
+  s=${s//$'\n'/\\n}
+  s=${s//$'\r'/\\r}
+  s=${s//$'\t'/\\t}
+  printf '%s' "$s"
+}
+
+open_file(){
+  local p=$1
+  if have xdg-open; then
+    xdg-open "$p" >/dev/null 2>&1 || true
+  elif have open; then
+    open "$p" >/dev/null 2>&1 || true
+  else
+    warn "no opener found (xdg-open/open); wrote: $p"
+  fi
+}
+
+usage(){
+  cat <<EOF
+sourceos (workstation helper)
+
+Usage:
+  sourceos doctor [--open]
+  sourceos status [--json|--open|--write <path>]
+  sourceos profile apply
+  sourceos profile path
+
+Env:
+  SOURCEOS_PROFILE_DIR                Override profile directory (default: $PROFILE_DIR_DEFAULT)
+  SOURCEOS_ALLOW_THIRDPARTY_REPOS     See gnome/albert-install.sh
+EOF
+}
+
+run_doctor(){
+  local doc="$PROFILE_DIR/doctor.sh"
+  [[ -x "$doc" ]] || { err "doctor not found: $doc"; exit 2; }
+  exec "$doc"
+}
+
+run_doctor_open(){
+  local doc="$PROFILE_DIR/doctor.sh"
+  [[ -x "$doc" ]] || { err "doctor not found: $doc"; exit 2; }
+
+  local d
+  d="$(cache_dir)"
+  mkdir -p "$d"
+  local out="$d/doctor.txt"
+
+  set +e
+  "$doc" >"$out" 2>&1
+  local rc=$?
+  set -e
+
+  open_file "$out"
+  exit "$rc"
+}
+
+run_apply(){
+  local inst="$PROFILE_DIR/install.sh"
+  [[ -x "$inst" ]] || { err "installer not found: $inst"; exit 2; }
+  exec "$inst"
+}
+
+profile_path(){
+  echo "$PROFILE_DIR"
+}
+
+gnome_detect(){
+  [[ "${XDG_CURRENT_DESKTOP:-}" == *GNOME* ]] && return 0
+  [[ "${DESKTOP_SESSION:-}" == *gnome* ]] && return 0
+  return 1
+}
+
+check_bin(){
+  local bin=$1
+  if have "$bin"; then
+    return 0
+  fi
+  return 1
+}
+
+status_collect(){
+  REQUIRED_MISSING=()
+  OPTIONAL_MISSING=()
+  WARNINGS=()
+
+  local required=(
+    git ssh podman toolbox wl-copy jq
+    brew sourceos
+    fzf atuin bat zoxide eza yazi gum direnv rg fd tmux
+    lazygit gh tig
+    sesh procs sd entr curlie
+    jnv gojq
+    rclone mc rsync
+  )
+
+  for b in "${required[@]}"; do
+    if ! check_bin "$b"; then
+      REQUIRED_MISSING+=("$b")
+    fi
+  done
+
+  if ! check_bin xclip; then
+    OPTIONAL_MISSING+=("xclip")
+  fi
+
+  if gnome_detect; then
+    if ! check_bin albert; then
+      REQUIRED_MISSING+=("albert")
+    fi
+
+    if ! check_bin gsettings; then
+      WARNINGS+=("gsettings missing")
+    fi
+
+    if check_bin gnome-extensions; then
+      if ! gnome-extensions list 2>/dev/null | grep -qx 'dash-to-dock@micxgx.gmail.com'; then
+        WARNINGS+=("missing gnome extension: dash-to-dock@micxgx.gmail.com")
+      fi
+      if ! gnome-extensions list 2>/dev/null | grep -qx 'appindicatorsupport@rgcjonas.gmail.com'; then
+        WARNINGS+=("missing gnome extension: appindicatorsupport@rgcjonas.gmail.com")
+      fi
+    else
+      WARNINGS+=("gnome-extensions missing")
+    fi
+  fi
+}
+
+status_json(){
+  status_collect
+
+  local ok=true
+  if (( ${#REQUIRED_MISSING[@]} > 0 )); then
+    ok=false
+  fi
+
+  local profile="linux-dev/workstation-v0"
+
+  local gnome=false
+  if gnome_detect; then gnome=true; fi
+
+  printf '{'
+  printf '"profile":"%s"' "$(json_escape "$profile")"
+  printf ',"ok":%s' "$ok"
+  printf ',"gnome":%s' "$gnome"
+
+  printf ',"required_missing":['
+  for ((i=0;i<${#REQUIRED_MISSING[@]};i++)); do
+    [[ $i -gt 0 ]] && printf ','
+    printf '"%s"' "$(json_escape "${REQUIRED_MISSING[$i]}")"
+  done
+  printf ']'
+
+  printf ',"optional_missing":['
+  for ((i=0;i<${#OPTIONAL_MISSING[@]};i++)); do
+    [[ $i -gt 0 ]] && printf ','
+    printf '"%s"' "$(json_escape "${OPTIONAL_MISSING[$i]}")"
+  done
+  printf ']'
+
+  printf ',"warnings":['
+  for ((i=0;i<${#WARNINGS[@]};i++)); do
+    [[ $i -gt 0 ]] && printf ','
+    printf '"%s"' "$(json_escape "${WARNINGS[$i]}")"
+  done
+  printf ']'
+
+  printf '}'
+  printf '\n'
+
+  if [[ "$ok" == "true" ]]; then
+    return 0
+  fi
+  return 2
+}
+
+status_human(){
+  status_collect
+
+  if (( ${#REQUIRED_MISSING[@]} == 0 )); then
+    info "status: OK"
+  else
+    err "status: FAIL"
+    err "missing required: ${REQUIRED_MISSING[*]}"
+    return 2
+  fi
+
+  if (( ${#OPTIONAL_MISSING[@]} > 0 )); then
+    warn "missing optional: ${OPTIONAL_MISSING[*]}"
+  fi
+
+  if (( ${#WARNINGS[@]} > 0 )); then
+    warn "warnings:"
+    for w in "${WARNINGS[@]}"; do
+      warn "- $w"
+    done
+  fi
+
+  return 0
+}
+
+status_open(){
+  local d
+  d="$(cache_dir)"
+  mkdir -p "$d"
+  local out="$d/status.json"
+
+  set +e
+  status_json >"$out" 2>/dev/null
+  local rc=$?
+  set -e
+
+  open_file "$out"
+  exit "$rc"
+}
+
+status_write(){
+  local path=$1
+  [[ -n "$path" ]] || { err "--write requires a path"; exit 2; }
+
+  local dir
+  dir="$(dirname "$path")"
+  mkdir -p "$dir"
+
+  set +e
+  status_json >"$path" 2>/dev/null
+  local rc=$?
+  set -e
+
+  info "wrote: $path"
+  exit "$rc"
+}
+
+main(){
+  local cmd=${1:-}
+  case "$cmd" in
+    -h|--help|help|"")
+      usage
+      ;;
+
+    doctor)
+      shift || true
+      case "${1:-}" in
+        --open) run_doctor_open ;;
+        "") run_doctor ;;
+        *) run_doctor ;;
+      esac
+      ;;
+
+    status)
+      shift || true
+      case "${1:-}" in
+        --json)
+          shift || true
+          status_json
+          ;;
+        --open)
+          shift || true
+          status_open
+          ;;
+        --write)
+          shift || true
+          status_write "${1:-}"
+          ;;
+        "")
+          status_human
+          ;;
+        *)
+          err "unknown status flag: ${1:-}"
+          usage
+          exit 2
+          ;;
+      esac
+      ;;
+
+    profile)
+      shift || true
+      local sub=${1:-}
+      case "$sub" in
+        apply)
+          run_apply
+          ;;
+        path)
+          profile_path
+          ;;
+        *)
+          err "unknown profile subcommand: $sub"
+          usage
+          exit 2
+          ;;
+      esac
+      ;;
+
+    *)
+      err "unknown command: $cmd"
+      usage
+      exit 2
+      ;;
+  esac
+}
+
+main "$@"

--- a/profiles/linux-dev/workstation-v0/doctor.sh
+++ b/profiles/linux-dev/workstation-v0/doctor.sh
@@ -59,6 +59,9 @@ main(){
   # USER expectations
   check brew
 
+  # SourceOS helper (needed for Albert SourceOS plugin actions)
+  check sourceos
+
   # Core CLI must-haves
   check fzf
   check atuin
@@ -91,12 +94,13 @@ main(){
   check mc
   check rsync
 
-  # GNOME baseline signals (non-fatal)
+  # GNOME expectations
   if gnome_detect; then
+    check albert
+
     if have gsettings; then
       info "gnome: detected; gsettings present"
 
-      # best-effort visibility of albert hotkey binding
       local base="/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/"
       local custom0="${base}custom0/"
       local bindings
@@ -112,7 +116,6 @@ main(){
       warn "gnome: detected but gsettings missing"
     fi
 
-    # Extension pinset (non-fatal)
     check_gnome_extension 'dash-to-dock@micxgx.gmail.com'
     check_gnome_extension 'appindicatorsupport@rgcjonas.gmail.com'
 

--- a/profiles/linux-dev/workstation-v0/gnome/albert-install.sh
+++ b/profiles/linux-dev/workstation-v0/gnome/albert-install.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install Albert on Fedora-based systems.
+# Strategy:
+#   1) Try native repos (dnf/rpm-ostree).
+#   2) If not available, *optionally* add the OBS repo from home:manuelschneid3r and retry.
+#
+# Trust note:
+# - Adding a third-party RPM repo expands the host trust boundary.
+# - Therefore the OBS fallback is gated behind:
+#     SOURCEOS_ALLOW_THIRDPARTY_REPOS=1
+
+info(){ printf "INFO: %s\n" "$*" >&2; }
+warn(){ printf "WARN: %s\n" "$*" >&2; }
+
+have(){ command -v "$1" >/dev/null 2>&1; }
+
+is_gnome(){
+  [[ "${XDG_CURRENT_DESKTOP:-}" == *GNOME* ]] && return 0
+  [[ "${DESKTOP_SESSION:-}" == *gnome* ]] && return 0
+  return 1
+}
+
+os_id(){
+  if [[ -r /etc/os-release ]]; then
+    . /etc/os-release
+    echo "${ID:-linux}"
+  else
+    echo "linux"
+  fi
+}
+
+os_version_id(){
+  if [[ -r /etc/os-release ]]; then
+    . /etc/os-release
+    echo "${VERSION_ID:-}"
+  else
+    echo ""
+  fi
+}
+
+allow_thirdparty_repos(){
+  case "${SOURCEOS_ALLOW_THIRDPARTY_REPOS:-0}" in
+    1|true|TRUE|yes|YES) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+fedora_obs_repofile_url(){
+  local v
+  v="$(os_version_id)"
+
+  if [[ "$v" == "rawhide" || "$v" == "Rawhide" || -z "$v" ]]; then
+    echo "https://download.opensuse.org/repositories/home:manuelschneid3r/Fedora_Rawhide/home:manuelschneid3r.repo"
+    return
+  fi
+
+  echo "https://download.opensuse.org/repositories/home:manuelschneid3r/Fedora_${v}/home:manuelschneid3r.repo"
+}
+
+install_obs_repo(){
+  local url
+  url="$(fedora_obs_repofile_url)"
+
+  local dest="/etc/yum.repos.d/home:manuelschneid3r.repo"
+
+  info "Adding OBS repo for Albert (home:manuelschneid3r): $url"
+
+  if have curl; then
+    curl -fsSL "$url" | sudo tee "$dest" >/dev/null
+  elif have wget; then
+    wget -qO- "$url" | sudo tee "$dest" >/dev/null
+  else
+    warn "Neither curl nor wget found; cannot add OBS repo automatically"
+    return 1
+  fi
+
+  info "Repo file installed: $dest"
+}
+
+try_install_native(){
+  if have rpm-ostree; then
+    info "Trying rpm-ostree install albert"
+    sudo rpm-ostree install albert || true
+    return 0
+  fi
+
+  if have dnf; then
+    info "Trying dnf install albert"
+    sudo dnf install -y albert || true
+    return 0
+  fi
+
+  warn "No rpm-ostree/dnf found; cannot install Albert"
+  return 1
+}
+
+try_install_with_obs(){
+  install_obs_repo || return 1
+
+  if have rpm-ostree; then
+    info "Retrying rpm-ostree install albert (with OBS repo)"
+    sudo rpm-ostree install albert || true
+    return 0
+  fi
+
+  if have dnf; then
+    info "Retrying dnf install albert (with OBS repo)"
+    sudo dnf install -y albert || true
+    return 0
+  fi
+
+  return 1
+}
+
+print_obs_instructions(){
+  local url
+  url="$(fedora_obs_repofile_url)"
+  warn "OBS fallback is disabled by default (trust boundary expansion)."
+  warn "To allow enabling the OBS repo automatically, set:"
+  warn "  export SOURCEOS_ALLOW_THIRDPARTY_REPOS=1"
+  warn "Then re-run this installer."
+  warn "If you prefer manual install, repo file URL is: $url"
+}
+
+main(){
+  if have albert; then
+    info "albert already present"
+    exit 0
+  fi
+
+  if ! is_gnome; then
+    warn "GNOME not detected; skipping Albert install"
+    exit 0
+  fi
+
+  local id
+  id="$(os_id)"
+
+  if [[ "$id" != "fedora" ]]; then
+    warn "Unsupported distro for Albert install (id=$id). Install Albert manually."
+    exit 0
+  fi
+
+  try_install_native
+
+  if have albert; then
+    info "albert installed (native repos)"
+    exit 0
+  fi
+
+  warn "Albert not found in native repos."
+
+  if ! allow_thirdparty_repos; then
+    print_obs_instructions
+    exit 2
+  fi
+
+  warn "Third-party repos allowed; attempting OBS repo fallback"
+  try_install_with_obs
+
+  if have albert; then
+    info "albert installed (OBS repo)"
+  else
+    warn "albert not found after install attempts."
+    warn "You may need to install manually from software.opensuse.org for your Fedora version."
+    exit 2
+  fi
+}
+
+main "$@"

--- a/profiles/linux-dev/workstation-v0/install.sh
+++ b/profiles/linux-dev/workstation-v0/install.sh
@@ -57,6 +57,16 @@ install_shell_spine(){
   info "Enable by sourcing it from your shell rc (zshrc/bashrc)."
 }
 
+install_sourceos_cli(){
+  local script="$PROFILE_DIR/bin/install-sourceos-cli.sh"
+  if [[ -x "$script" ]]; then
+    info "Installing SourceOS helper CLI to ~/.local/bin"
+    "$script" || warn "sourceos CLI install failed (non-fatal)"
+  else
+    warn "sourceos CLI installer not found: $script"
+  fi
+}
+
 apply_gnome_baseline(){
   local script="$PROFILE_DIR/gnome/apply.sh"
   if [[ -x "$script" ]]; then
@@ -77,6 +87,16 @@ apply_gnome_extensions(){
   fi
 }
 
+apply_albert_install(){
+  local script="$PROFILE_DIR/gnome/albert-install.sh"
+  if [[ -x "$script" ]]; then
+    info "Installing Albert (best-effort)"
+    "$script" || warn "Albert install failed (non-fatal)"
+  else
+    warn "Albert install script not found: $script"
+  fi
+}
+
 apply_albert_hotkey(){
   local script="$PROFILE_DIR/gnome/albert-hotkey.sh"
   if [[ -x "$script" ]]; then
@@ -92,8 +112,10 @@ main(){
   install_system
   install_user
   install_shell_spine
+  install_sourceos_cli
   apply_gnome_baseline
   apply_gnome_extensions
+  apply_albert_install
   apply_albert_hotkey
   info "installed workstation-v0 (linux-dev)"
   info "next: ./doctor.sh"


### PR DESCRIPTION
This PR resolves the conflict situation in PR #37 by re-applying the intended workstation-v0 linux-dev changes on top of the current `main` head.

What it adds:
- `profiles/linux-dev/workstation-v0/gnome/albert-install.sh`:
  - native install first (`dnf`/`rpm-ostree`)
  - gated OBS fallback behind `SOURCEOS_ALLOW_THIRDPARTY_REPOS=1`
- `profiles/linux-dev/workstation-v0/bin/sourceos` helper:
  - `doctor [--open]`
  - `status [--json|--open|--write]`
  - `profile apply`, `profile path`
- `profiles/linux-dev/workstation-v0/bin/install-sourceos-cli.sh`:
  - installs helper to `~/.local/bin/sourceos`
- wires `install.sh` to:
  - install the helper
  - run albert installer
- tightens `doctor.sh`:
  - requires `sourceos`
  - requires `albert` when GNOME detected

Notes:
- This PR intentionally avoids autostart automation.
- After this merges, the Albert SourceOS plugin follow-up (SociOS-Linux/albert PR #2) will have a stable command surface to invoke.

Supersedes:
- PR #37 (conflicted)
