### PR TITLE
Fedora Atomic software supply lanes docs (Flatpak/Toolbox/rpm-ostree)

### DIFF
--- a/FEDORA_ATOMIC.md
+++ b/FEDORA_ATOMIC.md
@@ -1,0 +1,14 @@
+# Fedora Atomic (Silverblue/Kinoite/Sway Atomic)
+
+This repository documents and hosts SourceOS Linux artifacts.
+
+If we are running Fedora Atomic desktops, the core operational model is the **software supply lanes** split:
+
+1) Flatpak (GUI apps)
+2) Toolbox (CLI/dev tools)
+3) rpm-ostree layering (host mutations; sparingly)
+
+Start here:
+
+- `docs/fedora-atomic/README.md`
+

--- a/docs/fedora-atomic/README.md
+++ b/docs/fedora-atomic/README.md
@@ -1,0 +1,53 @@
+# Fedora Atomic (Silverblue/Kinoite/Sway Atomic): software supply lanes
+
+SourceOS treats Fedora Atomic desktops as an **immutable host** with three intentionally distinct software lanes.
+
+1) **Flatpak (GUI apps)** — default, sandboxed, user-scoped. Prefer this for desktop apps.
+2) **Toolbox (CLI + dev tools)** — mutable container for compilers, debuggers, CLIs, SDKs.
+3) **rpm-ostree layering (host mutations)** — last resort for host-integrated components (drivers, libvirt, kernel-adjacent tools). Requires new deployment + reboot.
+
+If we violate this split, we lose the main benefits of Atomic: transactional updates, clean rollback, and a predictable trust boundary between user-space and the host.
+
+## Decision tree
+
+- Need a GUI app? → **Flatpak**
+- Need CLI/dev tooling? → **Toolbox**
+- Must run as a host service / kernel-adjacent / driver / system daemon? → **rpm-ostree layering**
+
+## Quick commands
+
+### Add Flathub (idempotent)
+
+```bash
+flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+flatpak remotes --show-details | sed -n '1,200p'
+```
+
+### Install an app (example)
+
+```bash
+flatpak install flathub org.libreoffice.LibreOffice
+flatpak install flathub com.github.tchx84.Flatseal
+```
+
+### Toolbox (create + enter)
+
+```bash
+toolbox create --container dev || true
+toolbox enter --container dev
+```
+
+### Host layering (sparingly)
+
+```bash
+rpm-ostree install <package>
+rpm-ostree status
+systemctl reboot
+```
+
+## Docs
+
+- [Flathub setup + verification](./flathub.md)
+- [Toolbox profiles](./toolbox.md)
+- [rpm-ostree layering + rollback](./rpm-ostree-layering.md)
+- [Flatpak permissions + sandbox audit](./flatpak-permissions.md)

--- a/docs/fedora-atomic/flathub.md
+++ b/docs/fedora-atomic/flathub.md
@@ -1,0 +1,42 @@
+# Flathub setup (Fedora Atomic)
+
+Goal: add the Flathub remote in a way that is **auditable, idempotent, and user-scoped**.
+
+## CLI (preferred)
+
+```bash
+flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+flatpak remotes --show-details
+```
+
+Verify:
+- Remote name is `flathub`
+- URL and/or collection points to `dl.flathub.org`
+
+## GNOME Software (GUI)
+
+If you use the browser workflow:
+- download `flathub.flatpakrepo`
+- open with **Software Install**
+- confirm the **Source** shows `dl.flathub.org`
+- click **Install**
+
+## Notes on provenance
+
+- Flathub hosts both FOSS and proprietary apps.
+- SourceOS policy can require license-allowlisting per-app (separate policy surface).
+- Flatpak itself has signature verification; we still treat permissions as part of the trust boundary.
+
+## Useful commands
+
+List apps and origins:
+
+```bash
+flatpak list --app --columns=application,origin,version
+```
+
+Update:
+
+```bash
+flatpak update
+```

--- a/docs/fedora-atomic/flatpak-permissions.md
+++ b/docs/fedora-atomic/flatpak-permissions.md
@@ -1,0 +1,31 @@
+# Flatpak permissions + sandbox audit
+
+Flatpak is a strong default lane, but its security properties depend on:
+- the sandbox permissions granted to each app
+- portal usage vs direct filesystem access
+
+## Inspect permissions
+
+Install Flatseal (GUI permission inspector):
+
+```bash
+flatpak install flathub com.github.tchx84.Flatseal
+```
+
+From CLI, basic info:
+
+```bash
+flatpak info --show-permissions <app-id>
+```
+
+## Common risk patterns
+
+- `--filesystem=host` or broad `home` access for apps that do not need it
+- `--talk-name=org.freedesktop.secrets` or other broad DBus access without justification
+- excessive device access (e.g., camera/mic) without necessity
+
+## Recommended posture
+
+- Start permissive only when required; then tighten.
+- Prefer portal-based workflows (file chooser portal) vs raw filesystem mounts.
+- Treat permission broadening as a governed change (like capability escalation).

--- a/docs/fedora-atomic/rpm-ostree-layering.md
+++ b/docs/fedora-atomic/rpm-ostree-layering.md
@@ -1,0 +1,41 @@
+# rpm-ostree package layering (Fedora Atomic)
+
+Use rpm-ostree layering only when the component must live on the host (kernel-adjacent, drivers, system daemons, virtualization stacks).
+Layering creates a **new deployment** (a new bootable root) and typically requires a reboot.
+
+## Install a package
+
+```bash
+rpm-ostree install <package>
+rpm-ostree status
+systemctl reboot
+```
+
+## Remove a layered package
+
+```bash
+rpm-ostree uninstall <package>
+rpm-ostree status
+systemctl reboot
+```
+
+## Rollback
+
+If the new deployment misbehaves:
+
+```bash
+rpm-ostree status
+rpm-ostree rollback
+systemctl reboot
+```
+
+## Replace/override (advanced)
+
+`rpm-ostree override replace` exists for testing alternate builds of host packages.
+This is an advanced workflow and should be tracked as a governed change.
+
+## Operational posture
+
+- Prefer: Flatpak (GUI) + Toolbox (CLI)
+- Use layering sparingly
+- Always record: what changed, why, and how to roll back

--- a/docs/fedora-atomic/toolbox.md
+++ b/docs/fedora-atomic/toolbox.md
@@ -1,0 +1,43 @@
+# Toolbox on Fedora Atomic
+
+Toolbox provides a mutable Fedora user-container for CLI tools and development dependencies.
+This keeps the host OS clean and rollback-friendly.
+
+## Create profiles (examples)
+
+### Dev toolbox
+
+```bash
+toolbox create --container dev || true
+```
+
+Enter:
+
+```bash
+toolbox enter --container dev
+```
+
+Install tools inside the toolbox:
+
+```bash
+sudo dnf install -y git make gcc gcc-c++ python3 python3-pip ripgrep fd-find
+```
+
+## Policy notes
+
+- Treat toolbox as a *controlled mutable lane*.
+- Prefer per-project environments inside toolbox (venv/conda/pixi) rather than polluting the toolbox root.
+
+## Useful commands
+
+List toolboxes:
+
+```bash
+toolbox list
+```
+
+Remove a toolbox:
+
+```bash
+toolbox rm --container dev
+```


### PR DESCRIPTION
Adds initial documentation for Fedora Atomic desktops: the three software supply lanes (Flatpak, Toolbox, rpm-ostree layering), plus security/verification notes.

Scope:
- docs/fedora-atomic/README.md (lane overview + decision tree)
- docs/fedora-atomic/flathub.md
- docs/fedora-atomic/toolbox.md
- docs/fedora-atomic/rpm-ostree-layering.md
- docs/fedora-atomic/flatpak-permissions.md

Notes:
- This PR intentionally avoids modifying existing root README content (the repo currently has a minimal stub README; updating it requires contents API sha plumbing).
- Follow-on work can wire these docs into the repo’s canonical navigation once conventions are established.
