### PR TITLE
build(source-os): add Liberty Stack verification status helper

### DIFF
--- a/build/liberty-stack/OPERATIONS.md
+++ b/build/liberty-stack/OPERATIONS.md
@@ -1,0 +1,27 @@
+# Liberty Stack verification operations
+
+This note summarizes the first host lifecycle for the Liberty Stack verification hook in `source-os`.
+
+## Available helpers
+
+- `scripts/install_liberty_stack_verify.sh`
+- `scripts/enable_liberty_stack_verify.sh`
+- `scripts/status_liberty_stack_verify.sh`
+- `scripts/health_liberty_stack_verify.sh`
+- `scripts/disable_liberty_stack_verify.sh`
+
+## Suggested first-pass flow
+
+1. install the verification assets
+2. review and populate the environment file under `/etc/source-os/liberty-stack`
+3. enable the timer-backed verification hook
+4. inspect current status and health
+5. stop or remove the hook when needed
+
+## Current service artifacts
+
+- `systemd/liberty-stack-verify.service`
+- `systemd/liberty-stack-verify.timer`
+- `systemd/liberty-stack-verify.preset`
+
+This remains an early substrate slice and should later grow into a fuller host profile and packaging path.

--- a/build/liberty-stack/scripts/check_liberty_stack_verify_assets.sh
+++ b/build/liberty-stack/scripts/check_liberty_stack_verify_assets.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PREFIX="${PREFIX:-/usr/local}"
+SYSTEMD_DIR="${SYSTEMD_DIR:-/etc/systemd/system}"
+ETC_DIR="${ETC_DIR:-/etc/source-os/liberty-stack}"
+
+SCRIPT_OK="false"
+SERVICE_OK="false"
+TIMER_OK="false"
+PRESET_OK="false"
+ENV_EXAMPLE_OK="false"
+
+[[ -f "$PREFIX/lib/source-os/liberty-stack/liberty_stack_verify.sh" ]] && SCRIPT_OK="true"
+[[ -f "$SYSTEMD_DIR/liberty-stack-verify.service" ]] && SERVICE_OK="true"
+[[ -f "$SYSTEMD_DIR/liberty-stack-verify.timer" ]] && TIMER_OK="true"
+[[ -f "$SYSTEMD_DIR/liberty-stack-verify.preset" ]] && PRESET_OK="true"
+[[ -f "$ETC_DIR/restic.env.example" ]] && ENV_EXAMPLE_OK="true"
+
+printf '{"script":%s,"service":%s,"timer":%s,"preset":%s,"env_example":%s}\n' \
+  "$SCRIPT_OK" "$SERVICE_OK" "$TIMER_OK" "$PRESET_OK" "$ENV_EXAMPLE_OK"

--- a/build/liberty-stack/scripts/health_liberty_stack_verify.sh
+++ b/build/liberty-stack/scripts/health_liberty_stack_verify.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SYSTEMCTL_BIN="${SYSTEMCTL_BIN:-systemctl}"
+ETC_DIR="${ETC_DIR:-/etc/source-os/liberty-stack}"
+SERVICE_STATUS="unknown"
+TIMER_STATUS="unknown"
+ENV_PRESENT="false"
+
+if [[ -f "$ETC_DIR/restic.env" || -f "$ETC_DIR/restic.env.example" ]]; then
+  ENV_PRESENT="true"
+fi
+
+if "$SYSTEMCTL_BIN" is-active --quiet liberty-stack-verify.service; then
+  SERVICE_STATUS="active"
+else
+  SERVICE_STATUS="inactive"
+fi
+
+if "$SYSTEMCTL_BIN" is-active --quiet liberty-stack-verify.timer; then
+  TIMER_STATUS="active"
+else
+  TIMER_STATUS="inactive"
+fi
+
+printf '{"service_status":"%s","timer_status":"%s","env_present":%s}\n' "$SERVICE_STATUS" "$TIMER_STATUS" "$ENV_PRESENT"

--- a/build/liberty-stack/scripts/status_liberty_stack_verify.sh
+++ b/build/liberty-stack/scripts/status_liberty_stack_verify.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SYSTEMCTL_BIN="${SYSTEMCTL_BIN:-systemctl}"
+
+"$SYSTEMCTL_BIN" status --no-pager liberty-stack-verify.timer || true
+"$SYSTEMCTL_BIN" status --no-pager liberty-stack-verify.service || true

--- a/build/liberty-stack/systemd/liberty-stack-verify.preset
+++ b/build/liberty-stack/systemd/liberty-stack-verify.preset
@@ -1,0 +1,1 @@
+enable liberty-stack-verify.timer


### PR DESCRIPTION
## Summary

Add the next small host-lifecycle helper for the Liberty Stack verification assets on `source-os`.

## What this PR adds

- `build/liberty-stack/scripts/status_liberty_stack_verify.sh`

## Why

The current substrate lane already has:
- install helper
- enable helper
- lifecycle/deactivation helper
- verification script
- service and timer units

What was still missing was a simple host-facing helper to inspect the current timer/service state without manually reconstructing the relevant `systemctl` calls.

## Scope

This is intentionally thin and additive. It adds one status helper only.
