### PR TITLE
build(source-os): add Liberty Stack verification doctor helper

### DIFF
--- a/build/liberty-stack/scripts/liberty_stack_verify_doctor.sh
+++ b/build/liberty-stack/scripts/liberty_stack_verify_doctor.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+STATUS_JSON="$($SCRIPT_DIR/status_liberty_stack_verify.sh 2>/dev/null || true)"
+HEALTH_JSON="$($SCRIPT_DIR/health_liberty_stack_verify.sh 2>/dev/null || true)"
+ASSET_JSON="$($SCRIPT_DIR/check_liberty_stack_verify_assets.sh 2>/dev/null || true)"
+
+printf '{"status":%s,"health":%s,"assets":%s}\n' \
+  "${STATUS_JSON:-null}" "${HEALTH_JSON:-null}" "${ASSET_JSON:-null}"


### PR DESCRIPTION
## Summary

Add a thin aggregated doctor helper for the Liberty Stack verification hook on `source-os`.

## What this PR adds

- `build/liberty-stack/scripts/liberty_stack_verify_doctor.sh`

## Why

The current substrate lane now has separate helpers for:
- status
- health
- installed-asset checking

This PR adds one small wrapper that runs those helpers and emits one combined JSON view, so operators have a single first-pass inspection command.

## Scope

This remains intentionally thin and additive. It does not replace the underlying helpers; it composes them.
