### PR TITLE
workstation-v0: install sourceos as profile-pinned wrapper

### DIFF
--- a/profiles/linux-dev/workstation-v0/bin/install-sourceos-cli.sh
+++ b/profiles/linux-dev/workstation-v0/bin/install-sourceos-cli.sh
@@ -3,24 +3,60 @@ set -euo pipefail
 
 # Install the profile-local `sourceos` helper CLI to user scope.
 # Target: ~/.local/bin/sourceos
+#
+# IMPORTANT:
+# - We do NOT copy the helper script itself into ~/.local/bin.
+# - Instead we install a small wrapper that pins the profile directory in
+#   $XDG_CONFIG_HOME/sourceos/profile.path and execs the profile-local helper.
+#
+# Rationale:
+# - The helper CLI is profile-scoped (linux-dev/workstation-v0). Copying it out of
+#   the profile directory breaks relative-path assumptions and can drift.
 
 PROFILE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-SRC="$PROFILE_DIR/bin/sourceos"
+IMPL="$PROFILE_DIR/bin/sourceos"
+
 DEST_DIR="${HOME}/.local/bin"
 DEST="$DEST_DIR/sourceos"
+
+CFG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/sourceos"
+PROFILE_FILE="$CFG_DIR/profile.path"
 
 info(){ printf "INFO: %s\n" "$*" >&2; }
 warn(){ printf "WARN: %s\n" "$*" >&2; }
 err(){ printf "ERROR: %s\n" "$*" >&2; }
 
 main(){
-  [[ -x "$SRC" ]] || { err "sourceos helper missing: $SRC"; exit 2; }
+  [[ -x "$IMPL" ]] || { err "sourceos helper missing: $IMPL"; exit 2; }
 
   mkdir -p "$DEST_DIR"
-  cp -f "$SRC" "$DEST"
+  mkdir -p "$CFG_DIR"
+
+  # Persist the profile dir
+  printf '%s\n' "$PROFILE_DIR" > "$PROFILE_FILE"
+
+  # Install wrapper
+  cat > "$DEST" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROFILE_FILE="${XDG_CONFIG_HOME:-$HOME/.config}/sourceos/profile.path"
+PROFILE_DIR="$(cat "$PROFILE_FILE" 2>/dev/null || true)"
+
+if [[ -z "$PROFILE_DIR" ]]; then
+  echo "ERROR: SourceOS profile path file missing or empty: $PROFILE_FILE" >&2
+  echo "Re-run the workstation profile installer to regenerate it." >&2
+  exit 2
+fi
+
+export SOURCEOS_PROFILE_DIR="$PROFILE_DIR"
+exec "$PROFILE_DIR/bin/sourceos" "$@"
+EOF
+
   chmod +x "$DEST"
 
-  info "installed: $DEST"
+  info "installed wrapper: $DEST"
+  info "pinned profile dir: $PROFILE_FILE"
 
   if [[ ":$PATH:" != *":$DEST_DIR:"* ]]; then
     warn "~/.local/bin is not on PATH. Add one line to your shell rc:"


### PR DESCRIPTION
Upstream-safe improvement to avoid fighting the system:

Problem:
- The workstation installs `sourceos` into `~/.local/bin` by copying the profile helper. Once moved, the helper’s default profile-dir computation no longer points at the profile and can drift.

Fix:
- `install-sourceos-cli.sh` now installs a *wrapper* into `~/.local/bin/sourceos`.
- The wrapper reads `$XDG_CONFIG_HOME/sourceos/profile.path` written at install time and execs the profile-local helper.

This makes launcher actions stable (Albert calls `sourceos …` and it always routes to the intended profile).

Notes:
- If the repo is moved, re-run the profile installer to repin the path.
- Follow-up PR can tighten `doctor.sh` to validate `sourceos profile path` matches this profile.
