### PR TITLE
docs(workstation): mention CI gate

### DIFF
--- a/docs/workstation/README.md
+++ b/docs/workstation/README.md
@@ -24,6 +24,9 @@ It triggers on PRs and main pushes touching:
 - `profiles/linux-dev/workstation-v0/**`
 - `docs/workstation/**`
 
+Workflow file:
+- `.github/workflows/workstation-scripts.yml`
+
 ## Workstation v0 goals
 
 - CLI-first developer experience with keyboard-first navigation.

--- a/docs/workstation/README.md
+++ b/docs/workstation/README.md
@@ -14,6 +14,16 @@ Placement rule:
 
 - [RUNBOOK.md](RUNBOOK.md) — operational “how we actually use it” steps
 
+## CI
+
+Workstation scripts are guarded by the `workstation-scripts` GitHub Actions workflow:
+- `shellcheck`
+- `bash -n`
+
+It triggers on PRs and main pushes touching:
+- `profiles/linux-dev/workstation-v0/**`
+- `docs/workstation/**`
+
 ## Workstation v0 goals
 
 - CLI-first developer experience with keyboard-first navigation.


### PR DESCRIPTION
Doc-only PR that mentions the workstation CI workflow in the workstation docs.

Status:
- Originally created to confirm the new `workstation-scripts` workflow triggers.
- The workflow ran and initially failed due to ShellCheck SC2088 in `install-sourceos-cli.sh` (tilde-in-quotes warning).
- That ShellCheck failure has now been fixed on `main` by PR #47.

Next action:
- Rebase/merge this PR (it should now run green).