### PR TITLE
ci: document and enforce workstation shellcheck policy

### DIFF
--- a/.github/workflows/workstation-scripts.yml
+++ b/.github/workflows/workstation-scripts.yml
@@ -27,22 +27,32 @@ jobs:
       - name: Shellcheck (workstation-v0)
         run: |
           set -euo pipefail
-          files=$(git ls-files 'profiles/linux-dev/workstation-v0/**/*.sh' 'profiles/linux-dev/workstation-v0/**/sourceos' 'profiles/linux-dev/workstation-v0/**/install-sourceos-cli.sh' || true)
+          # Policy: ShellCheck warnings are treated as failures for workstation-v0 scripts.
+          files=$(git ls-files 'profiles/linux-dev/workstation-v0/**/*.sh' \
+                              'profiles/linux-dev/workstation-v0/**/sourceos' \
+                              'profiles/linux-dev/workstation-v0/**/install-sourceos-cli.sh' || true)
           if [ -z "$files" ]; then
             echo "No scripts found."
             exit 0
           fi
-          echo "$files" | xargs -n1 shellcheck -S warning
+
+          fail=0
+          while IFS= read -r f; do
+            shellcheck -S warning "$f" || fail=1
+          done <<<"$files"
+          exit $fail
 
       - name: Bash syntax check (bash -n)
         run: |
           set -euo pipefail
-          files=$(git ls-files 'profiles/linux-dev/workstation-v0/**/*.sh' 'profiles/linux-dev/workstation-v0/**/sourceos' 'profiles/linux-dev/workstation-v0/**/install-sourceos-cli.sh' || true)
+          files=$(git ls-files 'profiles/linux-dev/workstation-v0/**/*.sh' \
+                              'profiles/linux-dev/workstation-v0/**/sourceos' \
+                              'profiles/linux-dev/workstation-v0/**/install-sourceos-cli.sh' || true)
           if [ -z "$files" ]; then
             echo "No scripts found."
             exit 0
           fi
-          echo "$files" | while read -r f; do
-            # shellcheck disable=SC2039
+
+          while IFS= read -r f; do
             bash -n "$f"
-          done
+          done <<<"$files"


### PR DESCRIPTION
Clarifies the workstation script CI policy and makes the shellcheck step deterministic.

Changes:
- `workstation-scripts.yml`: replace xargs invocation with an explicit loop and nonzero exit aggregation.
- Adds an explicit comment that ShellCheck warnings are treated as failures for workstation-v0 scripts.

This avoids accidental policy changes due to xargs exit codes and makes the enforcement intent explicit.
