### PR TITLE
flake: add albert-sourceos package (fork w/ SourceOS plugin)

### DIFF
--- a/.github/workflows/nix-build-albert-sourceos.yml
+++ b/.github/workflows/nix-build-albert-sourceos.yml
@@ -27,5 +27,7 @@ jobs:
       - name: Build albert-sourceos
         run: |
           set -euo pipefail
-          nix --version
-          nix build .#albert-sourceos --extra-experimental-features 'nix-command flakes' -L
+          # Ubuntu nix-bin is configured for daemon mode by default.
+          # GitHub runners do not run systemd; use local store mode for CI.
+          sudo nix --version
+          sudo env NIX_REMOTE=local nix build .#albert-sourceos --extra-experimental-features 'nix-command flakes' -L

--- a/.github/workflows/nix-build-albert-sourceos.yml
+++ b/.github/workflows/nix-build-albert-sourceos.yml
@@ -1,0 +1,31 @@
+name: nix-build-albert-sourceos
+
+on:
+  pull_request:
+    paths:
+      - 'flake.nix'
+      - 'flake.lock'
+      - '.github/workflows/nix-build-albert-sourceos.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'flake.nix'
+      - 'flake.lock'
+      - '.github/workflows/nix-build-albert-sourceos.yml'
+
+jobs:
+  build-albert-sourceos:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install nix (apt)
+        run: sudo apt-get update && sudo apt-get install -y nix-bin
+
+      - name: Build albert-sourceos
+        run: |
+          set -euo pipefail
+          nix --version
+          nix build .#albert-sourceos --extra-experimental-features 'nix-command flakes' -L

--- a/docs/workstation/RUNBOOK.md
+++ b/docs/workstation/RUNBOOK.md
@@ -139,9 +139,11 @@ The SourceOS Albert plugin lives in `SociOS-Linux/albert` (dev branch) and is in
 - `SourceOS: doctor` → `sourceos doctor --open`
 - plus quick-launch actions (sesh/tmux/k9s/lazygit/lazydocker/yazi)
 
-If you are using a distro-provided Albert package, it may not include this SourceOS plugin. In that case:
-- build/install Albert from `SociOS-Linux/albert`, or
-- package the plugin into your chosen distribution lane (future workstream).
+If you are using a distro-provided Albert package, it may not include this SourceOS plugin.
+
+Nix lane:
+- This repo provides a Nix package that builds Albert from the SourceOS fork (including `plugins/sourceos`).
+- Install it with `nix profile install .#albert-sourceos` and restart Albert.
 
 ---
 

--- a/flake.nix
+++ b/flake.nix
@@ -3,9 +3,16 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+    # SourceOS fork of Albert (dev branch) including the `plugins/sourceos` action bus plugin.
+    # Use git fetcher with submodules enabled because Albert relies on many submodules.
+    albert_src = {
+      url = "git+https://github.com/SociOS-Linux/albert?ref=dev&submodules=1";
+      flake = false;
+    };
   };
 
-  outputs = { self, nixpkgs }:
+  outputs = { self, nixpkgs, albert_src }:
     let
       lib = nixpkgs.lib;
       systems = [ "x86_64-linux" "aarch64-linux" ];
@@ -19,6 +26,14 @@
           meshd = pkgs.callPackage ./packages/mesh/meshd.nix { };
           meshd-linkd = pkgs.callPackage ./packages/mesh/meshd-linkd.nix { };
           meshd-exitd = pkgs.callPackage ./packages/mesh/meshd-exitd.nix { };
+
+          # Nix lane for Workstation v0: build Albert from our fork so the SourceOS plugin ships.
+          # This keeps clean installs from depending on distro packaging including our plugin.
+          albert-sourceos = pkgs.albert.overrideAttrs (old: {
+            src = albert_src;
+            version = "${old.version or "0.0.0"}-sourceos";
+          });
+
           default = meshd;
         });
 
@@ -81,6 +96,7 @@
               if [ -n "${missingStr}" ]; then
                 echo "NOTE: missing nixpkgs attrs (not added): ${missingStr}"
               fi
+              echo "Nix lane: build/install Albert with SourceOS plugin via: nix profile install .#albert-sourceos"
             '';
           };
         });


### PR DESCRIPTION
Closed: Albert is not OSI-open and is classified as `unfree` by nixpkgs.

See discussion in comments: `SociOS-Linux/albert` uses "Albert license v1.1" which permits redistribution only without modification and includes platform-targeting restrictions, making it incompatible with SourceOS constraints and with shipping a modified build including `plugins/sourceos`.

Replacement PR will pivot to an open-source launcher palette (Wayland-first; fuzzel/wofi/rofi) bound to Super+Space via `sourceos palette`.