### PR TITLE
docs/ci: align workstation docs to palette launcher + add sourceos JSON smoke test

### DIFF
--- a/.github/workflows/workstation-scripts.yml
+++ b/.github/workflows/workstation-scripts.yml
@@ -75,20 +75,8 @@ jobs:
             exit 1
           fi
 
-          python3 - <<'PY'
-import json, os, sys
-s = os.environ.get('OUT', '')
-try:
-    j = json.loads(s)
-except Exception as e:
-    print('JSON parse failed:', e, file=sys.stderr)
-    print('raw:', s, file=sys.stderr)
-    sys.exit(1)
-for k in ['profile','ok','gnome','required_missing','optional_missing','warnings']:
-    if k not in j:
-        print('missing key:', k, file=sys.stderr)
-        sys.exit(1)
-print('ok')
-PY
-        env:
-          OUT: "${out}"
+          python3 -c 'import json,sys; j=json.loads(sys.stdin.read());
+req=["profile","ok","gnome","required_missing","optional_missing","warnings"];
+miss=[k for k in req if k not in j];
+assert not miss, "missing keys: "+",".join(miss);
+print("ok")' <<<"$out"

--- a/.github/workflows/workstation-scripts.yml
+++ b/.github/workflows/workstation-scripts.yml
@@ -56,3 +56,39 @@ jobs:
           while IFS= read -r f; do
             bash -n "$f"
           done <<<"$files"
+
+      - name: Smoke: sourceos status JSON parses
+        run: |
+          set -euo pipefail
+          f='profiles/linux-dev/workstation-v0/bin/sourceos'
+          bash -n "$f"
+
+          # `sourceos status --json` may return exit 0 (all deps present) or 2 (missing deps).
+          # We only require the JSON output to parse and contain expected keys.
+          set +e
+          out=$(SOURCEOS_PROFILE_DIR=profiles/linux-dev/workstation-v0 bash "$f" status --json)
+          rc=$?
+          set -e
+
+          if [ "$rc" -ne 0 ] && [ "$rc" -ne 2 ]; then
+            echo "Unexpected exit code: $rc" >&2
+            exit 1
+          fi
+
+          python3 - <<'PY'
+import json, os, sys
+s = os.environ.get('OUT', '')
+try:
+    j = json.loads(s)
+except Exception as e:
+    print('JSON parse failed:', e, file=sys.stderr)
+    print('raw:', s, file=sys.stderr)
+    sys.exit(1)
+for k in ['profile','ok','gnome','required_missing','optional_missing','warnings']:
+    if k not in j:
+        print('missing key:', k, file=sys.stderr)
+        sys.exit(1)
+print('ok')
+PY
+        env:
+          OUT: "${out}"

--- a/docs/workstation/README.md
+++ b/docs/workstation/README.md
@@ -17,8 +17,9 @@ Placement rule:
 ## CI
 
 Workstation scripts are guarded by the `workstation-scripts` GitHub Actions workflow:
-- `shellcheck`
-- `bash -n`
+- shellcheck
+- bash -n
+- a small `sourceos status --json` smoke parse
 
 It triggers on PRs and main pushes touching:
 - `profiles/linux-dev/workstation-v0/**`
@@ -31,51 +32,38 @@ Workflow file:
 
 - CLI-first developer experience with keyboard-first navigation.
 - GNOME baseline customization via GSettings and pinned extensions (no GNOME core forks).
-- Albert as an **action bus** with `sourceos` actions.
-- Local status/doctor surfaces that can be opened from the launcher.
+- Open-source launcher palette (Wayland-first): `sourceos palette` uses fuzzel (primary) with wofi/rofi fallbacks.
+- Local status/doctor surfaces that can be opened from the launcher (`sourceos status --open`, `sourceos doctor --open`).
 
 ## Apply
 
 From the repo:
 
-```bash
-./profiles/linux-dev/workstation-v0/install.sh
-```
+  ./profiles/linux-dev/workstation-v0/install.sh
 
 ## Validate
 
-```bash
-./profiles/linux-dev/workstation-v0/doctor.sh
-```
+  ./profiles/linux-dev/workstation-v0/doctor.sh
 
 Or via the installed helper:
 
-```bash
-sourceos doctor
-sourceos status --json
-```
+  sourceos doctor
+  sourceos status --json
 
 ## Nix-first support
 
 This repository is Nix-native. A dev shell is provided:
 
-```bash
-nix develop .#workstation-v0
-```
+  nix develop .#workstation-v0
 
 Notes:
 - The workstation devShell is best-effort; missing nixpkgs attrs will be reported on entry.
-- The profile installers still support non-Nix systems using `dnf/rpm-ostree` and `brew` where applicable.
+- The profile installers still support non-Nix systems using dnf/rpm-ostree and brew where applicable.
 
 ## Trust boundaries
 
-- Third-party RPM repo enablement (Albert OBS fallback) is gated behind:
-
-```bash
-export SOURCEOS_ALLOW_THIRDPARTY_REPOS=1
-```
-
-Without this, the installer prints explicit instructions and exits nonzero.
+- Workstation v0 avoids non-open launchers.
+- Launcher install is best-effort via distro packages (Fedora: fuzzel) and does not silently enable third-party repos.
 
 ## Related docs
 


### PR DESCRIPTION
Aligns workstation docs to the open-source palette launcher and hardens CI with a minimal smoke test.

Changes:
- `docs/workstation/README.md`: remove stale Albert references; document palette launcher; update trust boundary note.
- `.github/workflows/workstation-scripts.yml`: add a smoke step that runs `sourceos status --json` and validates JSON parses and contains expected keys (exit code 0 or 2 allowed).

This ensures:
- docs do not drift from the current workstation implementation
- CI catches accidental breakage of the `sourceos status` JSON contract
