### PR TITLE
workstation-v0: complete sourceos fix surface (shell+fish+revert)

### DIFF
--- a/.github/workflows/workstation-scripts.yml
+++ b/.github/workflows/workstation-scripts.yml
@@ -108,6 +108,22 @@ jobs:
           bash -n "$f"
           SOURCEOS_PROFILE_DIR=profiles/linux-dev/workstation-v0 bash "$f" --help >/dev/null
 
+      - name: Smoke: sourceos fix shell dry-run exits cleanly
+        run: |
+          set -euo pipefail
+          f='profiles/linux-dev/workstation-v0/bin/sourceos'
+          tmp=$(mktemp)
+          printf '# rc\n' > "$tmp"
+          SOURCEOS_PROFILE_DIR=profiles/linux-dev/workstation-v0 SOURCEOS_RC_FILES="$tmp" bash "$f" fix shell dry-run >/dev/null
+
+      - name: Smoke: sourceos fix fish dry-run exits cleanly
+        run: |
+          set -euo pipefail
+          f='profiles/linux-dev/workstation-v0/bin/sourceos'
+          tmp=$(mktemp)
+          printf '# fish\n' > "$tmp"
+          SOURCEOS_PROFILE_DIR=profiles/linux-dev/workstation-v0 SOURCEOS_FISH_CONFIG="$tmp" bash "$f" fix fish dry-run >/dev/null
+
       - name: Smoke: sourceos status JSON parses
         run: |
           set -euo pipefail

--- a/docs/workstation/RUNBOOK.md
+++ b/docs/workstation/RUNBOOK.md
@@ -64,17 +64,25 @@ Run:
 SOURCEOS_AUTOPATCH_SHELL=1 ./profiles/linux-dev/workstation-v0/install.sh
 ```
 
-Bash/Zsh helper:
+Unified command surface:
+
+```bash
+sourceos fix shell dry-run
+sourceos fix shell apply
+sourceos fix shell revert
+
+sourceos fix fish dry-run
+sourceos fix fish apply
+sourceos fix fish revert
+```
+
+Low-level helpers remain available too:
 
 ```bash
 ./profiles/linux-dev/workstation-v0/bin/patch-shell.sh dry-run
 ./profiles/linux-dev/workstation-v0/bin/patch-shell.sh apply
 ./profiles/linux-dev/workstation-v0/bin/patch-shell.sh revert
-```
 
-Fish helper:
-
-```bash
 ./profiles/linux-dev/workstation-v0/bin/patch-fish.sh dry-run
 ./profiles/linux-dev/workstation-v0/bin/patch-fish.sh apply
 ./profiles/linux-dev/workstation-v0/bin/patch-fish.sh revert
@@ -97,6 +105,13 @@ The palette is invoked by:
 ```bash
 sourceos palette
 ```
+
+The palette includes:
+- fix shell rc (dry-run/apply/revert)
+- fix fish config (dry-run/apply/revert)
+- status / doctor
+- profile apply
+- common TUI tools
 
 ---
 

--- a/profiles/linux-dev/workstation-v0/bin/sourceos
+++ b/profiles/linux-dev/workstation-v0/bin/sourceos
@@ -44,7 +44,8 @@ sourceos (workstation helper)
 
 Usage:
   sourceos palette
-  sourceos fix shell [apply|dry-run]
+  sourceos fix shell [apply|dry-run|revert]
+  sourceos fix fish [apply|dry-run|revert]
   sourceos doctor [--open]
   sourceos status [--json|--open|--write <path>]
   sourceos profile apply
@@ -52,6 +53,8 @@ Usage:
 
 Env:
   SOURCEOS_PROFILE_DIR   Override profile directory (default: $PROFILE_DIR_DEFAULT)
+  SOURCEOS_RC_FILES      Test hook for patch-shell.sh
+  SOURCEOS_FISH_CONFIG   Test hook for patch-fish.sh
 EOF
 }
 
@@ -93,6 +96,13 @@ run_fix_shell(){
   local mode=${1:-apply}
   local s="$PROFILE_DIR/bin/patch-shell.sh"
   [[ -x "$s" ]] || { err "patch-shell helper missing: $s"; exit 2; }
+  exec "$s" "$mode"
+}
+
+run_fix_fish(){
+  local mode=${1:-apply}
+  local s="$PROFILE_DIR/bin/patch-fish.sh"
+  [[ -x "$s" ]] || { err "patch-fish helper missing: $s"; exit 2; }
   exec "$s" "$mode"
 }
 
@@ -263,6 +273,10 @@ palette_menu(){
   cat <<'EOF'
 Palette: Fix shell rc (dry-run)	sourceos fix shell dry-run
 Palette: Fix shell rc (apply)	sourceos fix shell apply
+Palette: Revert shell rc patch	sourceos fix shell revert
+Palette: Fix fish config (dry-run)	sourceos fix fish dry-run
+Palette: Fix fish config (apply)	sourceos fix fish apply
+Palette: Revert fish config patch	sourceos fix fish revert
 Status (open report)	sourceos status --open
 Doctor (open report)	sourceos doctor --open
 Apply profile	sourceos profile apply
@@ -322,6 +336,10 @@ main(){
         shell)
           shift || true
           run_fix_shell "${1:-apply}"
+          ;;
+        fish)
+          shift || true
+          run_fix_fish "${1:-apply}"
           ;;
         *)
           err "unknown fix target: ${1:-}"


### PR DESCRIPTION
Completes the user-facing command surface for workstation-v0 shell patching.

Changes:
- `profiles/linux-dev/workstation-v0/bin/sourceos`
  - adds `sourceos fix fish [apply|dry-run|revert]`
  - exposes `revert` for shell as part of the top-level CLI
  - adds palette entries for:
    - shell dry-run/apply/revert
    - fish dry-run/apply/revert
- `docs/workstation/RUNBOOK.md`
  - aligns docs to the unified `sourceos fix ...` interface
- `.github/workflows/workstation-scripts.yml`
  - adds smoke tests for:
    - `sourceos fix shell dry-run`
    - `sourceos fix fish dry-run`

Why:
- PR #55 added autopatch and palette actions.
- PR #58 added helper-level revert + revert CI.
- This PR finishes the operator-facing interface so users do not need to call low-level helper scripts directly.
