### PR TITLE
workstation-v0: add composite fix-all surface + CI coverage

### DIFF
--- a/.github/workflows/workstation-scripts.yml
+++ b/.github/workflows/workstation-scripts.yml
@@ -101,12 +101,41 @@ jobs:
           ! grep -qF '# >>> sourceos workstation-v0 (fish) >>>' "$tmp"
           ! grep -qF '# <<< sourceos workstation-v0 (fish) <<<' "$tmp"
 
+      - name: Smoke: patch-all apply/revert
+        run: |
+          set -euo pipefail
+          p='profiles/linux-dev/workstation-v0/bin/patch-all.sh'
+          bash -n "$p"
+
+          rc_tmp=$(mktemp)
+          fish_tmp=$(mktemp)
+          printf '# rc\n' > "$rc_tmp"
+          printf '# fish\n' > "$fish_tmp"
+
+          SOURCEOS_RC_FILES="$rc_tmp" SOURCEOS_FISH_CONFIG="$fish_tmp" bash "$p" apply
+          SOURCEOS_RC_FILES="$rc_tmp" SOURCEOS_FISH_CONFIG="$fish_tmp" bash "$p" revert
+
+          ! grep -qF '# >>> sourceos workstation-v0 >>>' "$rc_tmp"
+          ! grep -qF '# <<< sourceos workstation-v0 <<<' "$rc_tmp"
+          ! grep -qF '# >>> sourceos workstation-v0 (fish) >>>' "$fish_tmp"
+          ! grep -qF '# <<< sourceos workstation-v0 (fish) <<<' "$fish_tmp"
+
       - name: Smoke: sourceos help exits cleanly
         run: |
           set -euo pipefail
           f='profiles/linux-dev/workstation-v0/bin/sourceos'
           bash -n "$f"
           SOURCEOS_PROFILE_DIR=profiles/linux-dev/workstation-v0 bash "$f" --help >/dev/null
+
+      - name: Smoke: sourceos fix all dry-run exits cleanly
+        run: |
+          set -euo pipefail
+          f='profiles/linux-dev/workstation-v0/bin/sourceos'
+          rc_tmp=$(mktemp)
+          fish_tmp=$(mktemp)
+          printf '# rc\n' > "$rc_tmp"
+          printf '# fish\n' > "$fish_tmp"
+          SOURCEOS_PROFILE_DIR=profiles/linux-dev/workstation-v0 SOURCEOS_RC_FILES="$rc_tmp" SOURCEOS_FISH_CONFIG="$fish_tmp" bash "$f" fix all dry-run >/dev/null
 
       - name: Smoke: sourceos fix shell dry-run exits cleanly
         run: |

--- a/docs/workstation/RUNBOOK.md
+++ b/docs/workstation/RUNBOOK.md
@@ -48,17 +48,9 @@ Notes:
   - open-source launcher (fuzzel preferred) + SourceOS palette hotkey
   - `sourceos` helper wrapper into `~/.local/bin`
 
-### Optional: autopatch shell rc
+### Optional: autopatch shell/fish config
 
-If you want the installer to also patch your shell rc files:
-- bash/zsh: `~/.bashrc`, `~/.zshrc`
-- fish: `$XDG_CONFIG_HOME/fish/config.fish` (if present)
-
-It will:
-- ensure `$HOME/.local/bin` is on PATH
-- source the SourceOS shell spine
-
-Run:
+If you want the installer to also patch your shell config files, run:
 
 ```bash
 SOURCEOS_AUTOPATCH_SHELL=1 ./profiles/linux-dev/workstation-v0/install.sh
@@ -67,6 +59,10 @@ SOURCEOS_AUTOPATCH_SHELL=1 ./profiles/linux-dev/workstation-v0/install.sh
 Unified command surface:
 
 ```bash
+sourceos fix all dry-run
+sourceos fix all apply
+sourceos fix all revert
+
 sourceos fix shell dry-run
 sourceos fix shell apply
 sourceos fix shell revert
@@ -76,9 +72,17 @@ sourceos fix fish apply
 sourceos fix fish revert
 ```
 
+`fix all` orchestrates:
+- bash/zsh rc patch helper
+- fish config patch helper
+
 Low-level helpers remain available too:
 
 ```bash
+./profiles/linux-dev/workstation-v0/bin/patch-all.sh dry-run
+./profiles/linux-dev/workstation-v0/bin/patch-all.sh apply
+./profiles/linux-dev/workstation-v0/bin/patch-all.sh revert
+
 ./profiles/linux-dev/workstation-v0/bin/patch-shell.sh dry-run
 ./profiles/linux-dev/workstation-v0/bin/patch-shell.sh apply
 ./profiles/linux-dev/workstation-v0/bin/patch-shell.sh revert
@@ -107,6 +111,7 @@ sourceos palette
 ```
 
 The palette includes:
+- fix all configs (dry-run/apply/revert)
 - fix shell rc (dry-run/apply/revert)
 - fix fish config (dry-run/apply/revert)
 - status / doctor

--- a/profiles/linux-dev/workstation-v0/bin/patch-all.sh
+++ b/profiles/linux-dev/workstation-v0/bin/patch-all.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Composite patch helper for Workstation v0.
+# Runs shell and fish patch helpers in a single command surface.
+# Modes:
+# - apply (default)
+# - dry-run
+# - revert
+#
+# Behavior:
+# - shell helper is always invoked against bash/zsh rc candidates (or SOURCEOS_RC_FILES test hook)
+# - fish helper is invoked opportunistically; if fish config does not exist it exits cleanly
+
+MODE="${1:-apply}"
+PROFILE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+info(){ printf "INFO: %s\n" "$*" >&2; }
+warn(){ printf "WARN: %s\n" "$*" >&2; }
+err(){ printf "ERROR: %s\n" "$*" >&2; }
+
+run_one(){
+  local label=$1
+  local script=$2
+
+  if [[ ! -x "$script" ]]; then
+    warn "$label helper missing (skipping): $script"
+    return 0
+  fi
+
+  info "running $label helper: $script $MODE"
+  "$script" "$MODE"
+}
+
+main(){
+  case "$MODE" in
+    apply|dry-run|revert) ;;
+    *)
+      err "unknown mode: $MODE (use apply|dry-run|revert)"
+      exit 2
+      ;;
+  esac
+
+  run_one shell "$PROFILE_DIR/bin/patch-shell.sh"
+  run_one fish "$PROFILE_DIR/bin/patch-fish.sh"
+
+  info "fix-all complete ($MODE)"
+}
+
+main "$@"

--- a/profiles/linux-dev/workstation-v0/bin/sourceos
+++ b/profiles/linux-dev/workstation-v0/bin/sourceos
@@ -44,6 +44,7 @@ sourceos (workstation helper)
 
 Usage:
   sourceos palette
+  sourceos fix all [apply|dry-run|revert]
   sourceos fix shell [apply|dry-run|revert]
   sourceos fix fish [apply|dry-run|revert]
   sourceos doctor [--open]
@@ -90,6 +91,13 @@ run_apply(){
 
 profile_path(){
   echo "$PROFILE_DIR"
+}
+
+run_fix_all(){
+  local mode=${1:-apply}
+  local s="$PROFILE_DIR/bin/patch-all.sh"
+  [[ -x "$s" ]] || { err "patch-all helper missing: $s"; exit 2; }
+  exec "$s" "$mode"
 }
 
 run_fix_shell(){
@@ -271,6 +279,9 @@ status_write(){
 palette_menu(){
   # Print menu entries as: label<TAB>command
   cat <<'EOF'
+Palette: Fix all configs (dry-run)	sourceos fix all dry-run
+Palette: Fix all configs (apply)	sourceos fix all apply
+Palette: Revert all config patches	sourceos fix all revert
 Palette: Fix shell rc (dry-run)	sourceos fix shell dry-run
 Palette: Fix shell rc (apply)	sourceos fix shell apply
 Palette: Revert shell rc patch	sourceos fix shell revert
@@ -333,6 +344,10 @@ main(){
     fix)
       shift || true
       case "${1:-}" in
+        all)
+          shift || true
+          run_fix_all "${1:-apply}"
+          ;;
         shell)
           shift || true
           run_fix_shell "${1:-apply}"

--- a/profiles/linux-dev/workstation-v0/install.sh
+++ b/profiles/linux-dev/workstation-v0/install.sh
@@ -58,8 +58,11 @@ install_shell_spine(){
   local dst="${XDG_CONFIG_HOME:-$HOME/.config}/sourceos/shell"
   mkdir -p "$dst"
   cp -f "$PROFILE_DIR/shell/common.sh" "$dst/common.sh"
-  info "shell spine installed: $dst/common.sh"
-  info "Enable by sourcing it from your shell rc (zshrc/bashrc)."
+  if [[ -f "$PROFILE_DIR/shell/common.fish" ]]; then
+    cp -f "$PROFILE_DIR/shell/common.fish" "$dst/common.fish"
+  fi
+  info "shell spine installed: $dst"
+  info "Enable by sourcing it from your shell rc or use the autopatch helpers."
 }
 
 install_sourceos_cli(){
@@ -77,6 +80,14 @@ patch_shell_rc_if_enabled(){
     return 0
   fi
 
+  local all_script="$PROFILE_DIR/bin/patch-all.sh"
+  if [[ -x "$all_script" ]]; then
+    info "Autopatch enabled: applying composite shell/fish patch helper"
+    "$all_script" apply || warn "composite patch helper failed (non-fatal)"
+    return 0
+  fi
+
+  # Fallback for partial installs.
   local sh_script="$PROFILE_DIR/bin/patch-shell.sh"
   if [[ -x "$sh_script" ]]; then
     info "Autopatch enabled: patching shell rc files"
@@ -85,7 +96,6 @@ patch_shell_rc_if_enabled(){
     warn "autopatch enabled but patch helper missing: $sh_script"
   fi
 
-  # Optional: patch fish config if present.
   local fish_script="$PROFILE_DIR/bin/patch-fish.sh"
   if [[ -x "$fish_script" ]]; then
     info "Autopatch enabled: patching fish config (if present)"


### PR DESCRIPTION
Adds a higher-level operator surface for workstation shell/fish patching.

Changes:
- `profiles/linux-dev/workstation-v0/bin/patch-all.sh`
  - composite helper that orchestrates shell + fish apply/dry-run/revert
- `profiles/linux-dev/workstation-v0/bin/sourceos`
  - adds `sourceos fix all [apply|dry-run|revert]`
  - adds palette entries for fix-all dry-run/apply/revert
- `profiles/linux-dev/workstation-v0/install.sh`
  - when `SOURCEOS_AUTOPATCH_SHELL=1`, prefer `patch-all.sh` over per-helper wiring
- `docs/workstation/RUNBOOK.md`
  - documents the composite `fix all` surface
- `.github/workflows/workstation-scripts.yml`
  - adds `patch-all` apply/revert smoke test
  - adds `sourceos fix all dry-run` smoke test

Why:
- PR #55 added autopatch helpers.
- PR #58 added revert.
- PR #59 completed the top-level shell/fish surface.
- This PR adds the final composite operator command so users can patch all supported shell configs in one action.
