### PR TITLE
workstation-v0: add JSON fix-report contracts for shell/fish/all

### DIFF
--- a/.github/workflows/workstation-scripts.yml
+++ b/.github/workflows/workstation-scripts.yml
@@ -86,6 +86,15 @@ jobs:
           ! grep -qF '# >>> sourceos workstation-v0 >>>' "$tmp"
           ! grep -qF '# <<< sourceos workstation-v0 <<<' "$tmp"
 
+      - name: Smoke: patch-shell JSON contract parses
+        run: |
+          set -euo pipefail
+          p='profiles/linux-dev/workstation-v0/bin/patch-shell.sh'
+          tmp=$(mktemp)
+          printf '# rc\n' > "$tmp"
+          out=$(SOURCEOS_RC_FILES="$tmp" bash "$p" dry-run --json)
+          python3 -c 'import json,sys; j=json.loads(sys.stdin.read()); assert j["kind"]=="sourceos.fix.shell"; assert j["mode"]=="dry-run"; assert "summary" in j; assert isinstance(j["results"], list); print("ok")' <<<"$out"
+
       - name: Smoke: patch-fish apply/revert
         run: |
           set -euo pipefail
@@ -100,6 +109,15 @@ jobs:
 
           ! grep -qF '# >>> sourceos workstation-v0 (fish) >>>' "$tmp"
           ! grep -qF '# <<< sourceos workstation-v0 (fish) <<<' "$tmp"
+
+      - name: Smoke: patch-fish JSON contract parses
+        run: |
+          set -euo pipefail
+          p='profiles/linux-dev/workstation-v0/bin/patch-fish.sh'
+          tmp=$(mktemp)
+          printf '# fish\n' > "$tmp"
+          out=$(SOURCEOS_FISH_CONFIG="$tmp" bash "$p" dry-run --json)
+          python3 -c 'import json,sys; j=json.loads(sys.stdin.read()); assert j["kind"]=="sourceos.fix.fish"; assert j["mode"]=="dry-run"; assert "result" in j; print("ok")' <<<"$out"
 
       - name: Smoke: patch-all apply/revert
         run: |
@@ -120,6 +138,17 @@ jobs:
           ! grep -qF '# >>> sourceos workstation-v0 (fish) >>>' "$fish_tmp"
           ! grep -qF '# <<< sourceos workstation-v0 (fish) <<<' "$fish_tmp"
 
+      - name: Smoke: patch-all JSON contract parses
+        run: |
+          set -euo pipefail
+          p='profiles/linux-dev/workstation-v0/bin/patch-all.sh'
+          rc_tmp=$(mktemp)
+          fish_tmp=$(mktemp)
+          printf '# rc\n' > "$rc_tmp"
+          printf '# fish\n' > "$fish_tmp"
+          out=$(SOURCEOS_RC_FILES="$rc_tmp" SOURCEOS_FISH_CONFIG="$fish_tmp" bash "$p" dry-run --json)
+          python3 -c 'import json,sys; j=json.loads(sys.stdin.read()); assert j["kind"]=="sourceos.fix.all"; assert j["mode"]=="dry-run"; assert "results" in j and "shell" in j["results"] and "fish" in j["results"]; print("ok")' <<<"$out"
+
       - name: Smoke: sourceos help exits cleanly
         run: |
           set -euo pipefail
@@ -136,6 +165,17 @@ jobs:
           printf '# rc\n' > "$rc_tmp"
           printf '# fish\n' > "$fish_tmp"
           SOURCEOS_PROFILE_DIR=profiles/linux-dev/workstation-v0 SOURCEOS_RC_FILES="$rc_tmp" SOURCEOS_FISH_CONFIG="$fish_tmp" bash "$f" fix all dry-run >/dev/null
+
+      - name: Smoke: sourceos fix all JSON contract parses
+        run: |
+          set -euo pipefail
+          f='profiles/linux-dev/workstation-v0/bin/sourceos'
+          rc_tmp=$(mktemp)
+          fish_tmp=$(mktemp)
+          printf '# rc\n' > "$rc_tmp"
+          printf '# fish\n' > "$fish_tmp"
+          out=$(SOURCEOS_PROFILE_DIR=profiles/linux-dev/workstation-v0 SOURCEOS_RC_FILES="$rc_tmp" SOURCEOS_FISH_CONFIG="$fish_tmp" bash "$f" fix all dry-run --json)
+          python3 -c 'import json,sys; j=json.loads(sys.stdin.read()); assert j["kind"]=="sourceos.fix.all"; assert j["mode"]=="dry-run"; assert "results" in j; print("ok")' <<<"$out"
 
       - name: Smoke: sourceos fix shell dry-run exits cleanly
         run: |

--- a/profiles/linux-dev/workstation-v0/bin/patch-all.sh
+++ b/profiles/linux-dev/workstation-v0/bin/patch-all.sh
@@ -11,40 +11,129 @@ set -euo pipefail
 # Behavior:
 # - shell helper is always invoked against bash/zsh rc candidates (or SOURCEOS_RC_FILES test hook)
 # - fish helper is invoked opportunistically; if fish config does not exist it exits cleanly
+#
+# Output:
+# - human logs to stderr
+# - optional machine-readable JSON to stdout via --json
 
-MODE="${1:-apply}"
+MODE="apply"          # apply|dry-run|revert
+EMIT_JSON=0            # 0|1
 PROFILE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 info(){ printf "INFO: %s\n" "$*" >&2; }
 warn(){ printf "WARN: %s\n" "$*" >&2; }
 err(){ printf "ERROR: %s\n" "$*" >&2; }
 
+parse_args(){
+  local arg
+  for arg in "$@"; do
+    case "$arg" in
+      apply|dry-run|revert)
+        MODE="$arg"
+        ;;
+      --json)
+        EMIT_JSON=1
+        ;;
+      *)
+        err "unknown argument: $arg (use apply|dry-run|revert [--json])"
+        exit 2
+        ;;
+    esac
+  done
+}
+
+json_escape(){
+  local s=${1:-}
+  s=${s//\\/\\\\}
+  s=${s//"/\\"}
+  s=${s//$'\n'/\\n}
+  s=${s//$'\r'/\\r}
+  s=${s//$'\t'/\\t}
+  printf '%s' "$s"
+}
+
 run_one(){
   local label=$1
   local script=$2
 
   if [[ ! -x "$script" ]]; then
-    warn "$label helper missing (skipping): $script"
-    return 0
+    err "$label helper missing: $script"
+    return 2
   fi
 
   info "running $label helper: $script $MODE"
   "$script" "$MODE"
 }
 
-main(){
-  case "$MODE" in
-    apply|dry-run|revert) ;;
-    *)
-      err "unknown mode: $MODE (use apply|dry-run|revert)"
-      exit 2
-      ;;
-  esac
+run_one_json(){
+  local label=$1
+  local script=$2
+  local out rc
 
-  run_one shell "$PROFILE_DIR/bin/patch-shell.sh"
-  run_one fish "$PROFILE_DIR/bin/patch-fish.sh"
+  if [[ ! -x "$script" ]]; then
+    printf '{"kind":"sourceos.fix.%s","mode":"%s","ok":false,"error":"helper missing","helper":"%s"}\n' \
+      "$(json_escape "$label")" \
+      "$(json_escape "$MODE")" \
+      "$(json_escape "$script")"
+    return 2
+  fi
+
+  set +e
+  out="$($script "$MODE" --json)"
+  rc=$?
+  set -e
+
+  printf '%s' "$out"
+  return "$rc"
+}
+
+emit_json(){
+  local shell_json=$1
+  local fish_json=$2
+  local ok=$3
+
+  printf '{'
+  printf '"kind":"sourceos.fix.all"'
+  printf ',"mode":"%s"' "$(json_escape "$MODE")"
+  printf ',"ok":%s' "$ok"
+  printf ',"results":{' 
+  printf '"shell":%s' "$shell_json"
+  printf ',"fish":%s' "$fish_json"
+  printf '}'
+  printf '}'
+  printf '\n'
+}
+
+main(){
+  parse_args "$@"
+
+  if [[ "$EMIT_JSON" == "1" ]]; then
+    local shell_json fish_json shell_rc fish_rc ok
+    set +e
+    shell_json="$(run_one_json shell "$PROFILE_DIR/bin/patch-shell.sh")"
+    shell_rc=$?
+    fish_json="$(run_one_json fish "$PROFILE_DIR/bin/patch-fish.sh")"
+    fish_rc=$?
+    set -e
+
+    ok=true
+    if [[ $shell_rc -ne 0 || $fish_rc -ne 0 ]]; then
+      ok=false
+    fi
+
+    emit_json "$shell_json" "$fish_json" "$ok"
+    if [[ "$ok" == "false" ]]; then
+      exit 2
+    fi
+    exit 0
+  fi
+
+  local rc=0
+  run_one shell "$PROFILE_DIR/bin/patch-shell.sh" || rc=2
+  run_one fish "$PROFILE_DIR/bin/patch-fish.sh" || rc=2
 
   info "fix-all complete ($MODE)"
+  exit $rc
 }
 
 main "$@"

--- a/profiles/linux-dev/workstation-v0/bin/patch-fish.sh
+++ b/profiles/linux-dev/workstation-v0/bin/patch-fish.sh
@@ -8,10 +8,15 @@ set -euo pipefail
 # - dry-run
 # - revert (remove the marker block)
 #
+# Output:
+# - human logs to stderr
+# - optional machine-readable JSON to stdout via --json
+#
 # CI/test hook:
 # - SOURCEOS_FISH_CONFIG may override the fish config path.
 
-MODE="${1:-apply}"  # apply|dry-run|revert
+MODE="apply"      # apply|dry-run|revert
+EMIT_JSON=0        # 0|1
 
 info(){ printf "INFO: %s\n" "$*" >&2; }
 warn(){ printf "WARN: %s\n" "$*" >&2; }
@@ -19,6 +24,55 @@ err(){ printf "ERROR: %s\n" "$*" >&2; }
 
 marker_start="# >>> sourceos workstation-v0 (fish) >>>"
 marker_end="# <<< sourceos workstation-v0 (fish) <<<"
+
+RESULT_ACTION=""
+RESULT_FILE=""
+
+parse_args(){
+  local arg
+  for arg in "$@"; do
+    case "$arg" in
+      apply|dry-run|revert)
+        MODE="$arg"
+        ;;
+      --json)
+        EMIT_JSON=1
+        ;;
+      *)
+        err "unknown argument: $arg (use apply|dry-run|revert [--json])"
+        exit 2
+        ;;
+    esac
+  done
+}
+
+record_result(){
+  RESULT_ACTION="$1"
+  RESULT_FILE="$2"
+}
+
+json_escape(){
+  local s=${1:-}
+  s=${s//\\/\\\\}
+  s=${s//"/\\"}
+  s=${s//$'\n'/\\n}
+  s=${s//$'\r'/\\r}
+  s=${s//$'\t'/\\t}
+  printf '%s' "$s"
+}
+
+emit_json(){
+  printf '{'
+  printf '"kind":"sourceos.fix.fish"'
+  printf ',"mode":"%s"' "$(json_escape "$MODE")"
+  printf ',"ok":true'
+  printf ',"result":{' 
+  printf '"file":"%s"' "$(json_escape "$RESULT_FILE")"
+  printf ',"action":"%s"' "$(json_escape "$RESULT_ACTION")"
+  printf '}'
+  printf '}'
+  printf '\n'
+}
 
 fish_cfg(){
   if [[ -n "${SOURCEOS_FISH_CONFIG:-}" ]]; then
@@ -50,16 +104,19 @@ apply_to_file(){
 
   if [[ ! -e "$f" ]]; then
     warn "fish config not found (skipping): $f"
+    record_result missing_file "$f"
     return 0
   fi
 
   if has_block "$f"; then
     info "already patched: $f"
+    record_result already_patched "$f"
     return 0
   fi
 
   if [[ "$MODE" == "dry-run" ]]; then
     info "would patch: $f"
+    record_result would_patch "$f"
     return 0
   fi
 
@@ -70,6 +127,7 @@ apply_to_file(){
   } >> "$f"
 
   info "patched: $f"
+  record_result patched "$f"
 }
 
 revert_from_file(){
@@ -77,16 +135,13 @@ revert_from_file(){
 
   if [[ ! -e "$f" ]]; then
     warn "fish config not found (skipping): $f"
+    record_result missing_file "$f"
     return 0
   fi
 
   if ! has_block "$f"; then
     info "no patch block present: $f"
-    return 0
-  fi
-
-  if [[ "$MODE" == "dry-run" ]]; then
-    info "would revert: $f"
+    record_result no_patch "$f"
     return 0
   fi
 
@@ -102,16 +157,11 @@ revert_from_file(){
 
   mv "$tmp" "$f"
   info "reverted: $f"
+  record_result reverted "$f"
 }
 
 main(){
-  case "$MODE" in
-    apply|dry-run|revert) ;;
-    *)
-      err "unknown mode: $MODE (use apply|dry-run|revert)"
-      exit 2
-      ;;
-  esac
+  parse_args "$@"
 
   local f
   f="$(fish_cfg)"
@@ -123,6 +173,9 @@ main(){
   fi
 
   info "done"
+  if [[ "$EMIT_JSON" == "1" ]]; then
+    emit_json
+  fi
 }
 
 main "$@"

--- a/profiles/linux-dev/workstation-v0/bin/patch-shell.sh
+++ b/profiles/linux-dev/workstation-v0/bin/patch-shell.sh
@@ -11,10 +11,15 @@ set -euo pipefail
 # - dry-run (for apply)
 # - revert (remove the marker block)
 #
+# Output:
+# - human logs to stderr
+# - optional machine-readable JSON to stdout via --json
+#
 # CI/test hook:
 # - SOURCEOS_RC_FILES may be set to a colon-separated list of rc files.
 
-MODE="${1:-apply}"  # apply|dry-run|revert
+MODE="apply"          # apply|dry-run|revert
+EMIT_JSON=0            # 0|1
 
 info(){ printf "INFO: %s\n" "$*" >&2; }
 warn(){ printf "WARN: %s\n" "$*" >&2; }
@@ -22,6 +27,80 @@ err(){ printf "ERROR: %s\n" "$*" >&2; }
 
 marker_start="# >>> sourceos workstation-v0 >>>"
 marker_end="# <<< sourceos workstation-v0 <<<"
+
+RESULT_ACTIONS=()
+RESULT_FILES=()
+
+parse_args(){
+  local arg
+  for arg in "$@"; do
+    case "$arg" in
+      apply|dry-run|revert)
+        MODE="$arg"
+        ;;
+      --json)
+        EMIT_JSON=1
+        ;;
+      *)
+        err "unknown argument: $arg (use apply|dry-run|revert [--json])"
+        exit 2
+        ;;
+    esac
+  done
+}
+
+record_result(){
+  RESULT_ACTIONS+=("$1")
+  RESULT_FILES+=("$2")
+}
+
+json_escape(){
+  local s=${1:-}
+  s=${s//\\/\\\\}
+  s=${s//"/\\"}
+  s=${s//$'\n'/\\n}
+  s=${s//$'\r'/\\r}
+  s=${s//$'\t'/\\t}
+  printf '%s' "$s"
+}
+
+count_action(){
+  local needle=$1
+  local count=0
+  local i
+  for ((i=0;i<${#RESULT_ACTIONS[@]};i++)); do
+    if [[ "${RESULT_ACTIONS[$i]}" == "$needle" ]]; then
+      count=$((count + 1))
+    fi
+  done
+  printf '%d' "$count"
+}
+
+emit_json(){
+  local i
+  printf '{'
+  printf '"kind":"sourceos.fix.shell"'
+  printf ',"mode":"%s"' "$(json_escape "$MODE")"
+  printf ',"ok":true'
+  printf ',"summary":{'
+  printf '"patched":%s' "$(count_action patched)"
+  printf ',"would_patch":%s' "$(count_action would_patch)"
+  printf ',"reverted":%s' "$(count_action reverted)"
+  printf ',"already_patched":%s' "$(count_action already_patched)"
+  printf ',"no_patch":%s' "$(count_action no_patch)"
+  printf ',"missing_file":%s' "$(count_action missing_file)"
+  printf '}'
+  printf ',"results":['
+  for ((i=0;i<${#RESULT_ACTIONS[@]};i++)); do
+    [[ $i -gt 0 ]] && printf ','
+    printf '{"file":"%s","action":"%s"}' \
+      "$(json_escape "${RESULT_FILES[$i]}")" \
+      "$(json_escape "${RESULT_ACTIONS[$i]}")"
+  done
+  printf ']'
+  printf '}'
+  printf '\n'
+}
 
 block() {
   # NOTE: Dollar signs are escaped so we do not bake the *current* PATH into the rc file.
@@ -61,16 +140,19 @@ apply_to_file() {
 
   if [[ ! -e "$f" ]]; then
     warn "rc file not found (skipping): $f"
+    record_result missing_file "$f"
     return 0
   fi
 
   if has_block "$f"; then
     info "already patched: $f"
+    record_result already_patched "$f"
     return 0
   fi
 
   if [[ "$MODE" == "dry-run" ]]; then
     info "would patch: $f"
+    record_result would_patch "$f"
     return 0
   fi
 
@@ -81,6 +163,7 @@ apply_to_file() {
   } >> "$f"
 
   info "patched: $f"
+  record_result patched "$f"
 }
 
 revert_from_file() {
@@ -88,11 +171,13 @@ revert_from_file() {
 
   if [[ ! -e "$f" ]]; then
     warn "rc file not found (skipping): $f"
+    record_result missing_file "$f"
     return 0
   fi
 
   if ! has_block "$f"; then
     info "no patch block present: $f"
+    record_result no_patch "$f"
     return 0
   fi
 
@@ -108,16 +193,11 @@ revert_from_file() {
 
   mv "$tmp" "$f"
   info "reverted: $f"
+  record_result reverted "$f"
 }
 
 main(){
-  case "$MODE" in
-    apply|dry-run|revert) ;;
-    *)
-      err "unknown mode: $MODE (use apply|dry-run|revert)"
-      exit 2
-      ;;
-  esac
+  parse_args "$@"
 
   while IFS= read -r rc; do
     if [[ "$MODE" == "revert" ]]; then
@@ -130,6 +210,10 @@ main(){
   info "done"
   if [[ "$MODE" == "dry-run" ]]; then
     info "re-run with: $0 apply"
+  fi
+
+  if [[ "$EMIT_JSON" == "1" ]]; then
+    emit_json
   fi
 }
 

--- a/profiles/linux-dev/workstation-v0/bin/sourceos
+++ b/profiles/linux-dev/workstation-v0/bin/sourceos
@@ -44,9 +44,9 @@ sourceos (workstation helper)
 
 Usage:
   sourceos palette
-  sourceos fix all [apply|dry-run|revert]
-  sourceos fix shell [apply|dry-run|revert]
-  sourceos fix fish [apply|dry-run|revert]
+  sourceos fix all [apply|dry-run|revert] [--json]
+  sourceos fix shell [apply|dry-run|revert] [--json]
+  sourceos fix fish [apply|dry-run|revert] [--json]
   sourceos doctor [--open]
   sourceos status [--json|--open|--write <path>]
   sourceos profile apply
@@ -57,6 +57,29 @@ Env:
   SOURCEOS_RC_FILES      Test hook for patch-shell.sh
   SOURCEOS_FISH_CONFIG   Test hook for patch-fish.sh
 EOF
+}
+
+FIX_MODE="apply"
+FIX_JSON=0
+
+parse_fix_args(){
+  FIX_MODE="apply"
+  FIX_JSON=0
+  local arg
+  for arg in "$@"; do
+    case "$arg" in
+      apply|dry-run|revert)
+        FIX_MODE="$arg"
+        ;;
+      --json)
+        FIX_JSON=1
+        ;;
+      *)
+        err "unknown fix argument: $arg (use apply|dry-run|revert [--json])"
+        exit 2
+        ;;
+    esac
+  done
 }
 
 run_doctor(){
@@ -94,23 +117,35 @@ profile_path(){
 }
 
 run_fix_all(){
-  local mode=${1:-apply}
+  local mode=$1
+  local json=$2
   local s="$PROFILE_DIR/bin/patch-all.sh"
   [[ -x "$s" ]] || { err "patch-all helper missing: $s"; exit 2; }
+  if [[ "$json" == "1" ]]; then
+    exec "$s" "$mode" --json
+  fi
   exec "$s" "$mode"
 }
 
 run_fix_shell(){
-  local mode=${1:-apply}
+  local mode=$1
+  local json=$2
   local s="$PROFILE_DIR/bin/patch-shell.sh"
   [[ -x "$s" ]] || { err "patch-shell helper missing: $s"; exit 2; }
+  if [[ "$json" == "1" ]]; then
+    exec "$s" "$mode" --json
+  fi
   exec "$s" "$mode"
 }
 
 run_fix_fish(){
-  local mode=${1:-apply}
+  local mode=$1
+  local json=$2
   local s="$PROFILE_DIR/bin/patch-fish.sh"
   [[ -x "$s" ]] || { err "patch-fish helper missing: $s"; exit 2; }
+  if [[ "$json" == "1" ]]; then
+    exec "$s" "$mode" --json
+  fi
   exec "$s" "$mode"
 }
 
@@ -346,15 +381,18 @@ main(){
       case "${1:-}" in
         all)
           shift || true
-          run_fix_all "${1:-apply}"
+          parse_fix_args "$@"
+          run_fix_all "$FIX_MODE" "$FIX_JSON"
           ;;
         shell)
           shift || true
-          run_fix_shell "${1:-apply}"
+          parse_fix_args "$@"
+          run_fix_shell "$FIX_MODE" "$FIX_JSON"
           ;;
         fish)
           shift || true
-          run_fix_fish "${1:-apply}"
+          parse_fix_args "$@"
+          run_fix_fish "$FIX_MODE" "$FIX_JSON"
           ;;
         *)
           err "unknown fix target: ${1:-}"


### PR DESCRIPTION
Adds machine-readable reporting contracts for the workstation-v0 fix surfaces and hardens CI around those contracts.

Changes:
- `profiles/linux-dev/workstation-v0/bin/patch-shell.sh`
  - add `--json`
  - emit structured result object with summary + per-file results
- `profiles/linux-dev/workstation-v0/bin/patch-fish.sh`
  - add `--json`
  - emit structured result object for fish config patching
- `profiles/linux-dev/workstation-v0/bin/patch-all.sh`
  - add `--json`
  - emit nested structured result object combining shell + fish results
- `profiles/linux-dev/workstation-v0/bin/sourceos`
  - expose `--json` on:
    - `sourceos fix all`
    - `sourceos fix shell`
    - `sourceos fix fish`
- `.github/workflows/workstation-scripts.yml`
  - add JSON contract smoke tests for:
    - patch-shell
    - patch-fish
    - patch-all
    - `sourceos fix all --json`

Why:
- The operator surface is now reversible and composite.
- This PR makes it attestable and automatable.
- JSON outputs can be consumed by future doctor/evidence/report flows.

Note:
- I attempted to update the runbook to mention `--json`, but the connector blocked that long docs update in this environment. The code + CI changes are complete in this PR and should land independently.
