### PR TITLE
docs(source-os): add office integration profile and build stub

### DIFF
--- a/build/office-suite/README.md
+++ b/build/office-suite/README.md
@@ -1,0 +1,14 @@
+# SourceOS Office Suite Build Surface
+
+This directory is the Linux and desktop realization surface for the SourceOS office suite.
+
+It should carry:
+- SourceOS office profile definitions
+- local verification and round-trip smoke helpers
+- document extraction helpers
+- profile-specific wrapper scripts
+
+The office suite product/domain semantics belong in `SocioProphet/prophet-workspace`.
+The cloud and runtime office control plane belongs in `SocioProphet/prophet-platform`.
+
+This directory is intentionally host-oriented.

--- a/build/office-suite/profiles/sourceos-office-profile.toml
+++ b/build/office-suite/profiles/sourceos-office-profile.toml
@@ -1,0 +1,30 @@
+profile_id = "sourceos-office-profile-v1"
+status = "draft"
+default_editor = "libreoffice"
+cloud_editor = "collabora"
+workspace_runtime = "prophet-platform"
+workspace_domain = "prophet-workspace"
+
+default_modes = ["sovereign", "interoperability", "migration", "cloud"]
+
+[formats]
+canonical = "ODF"
+interop = "OOXML"
+fixed_output = "PDF"
+
+[desktop]
+file_associations = true
+font_substitution = true
+templates = true
+local_extraction = true
+roundtrip_smoke = true
+
+[cloud]
+wopi_handoff = true
+versioned_saveback = true
+receipt_required = true
+
+[policy]
+macro_default = "disabled"
+external_templates = "warn"
+model_access = "policy-gated"

--- a/docs/SOURCEOS_OFFICE_INTEGRATION_PROFILE.md
+++ b/docs/SOURCEOS_OFFICE_INTEGRATION_PROFILE.md
@@ -1,0 +1,46 @@
+# SourceOS Office Integration Profile
+
+## Purpose
+
+This document defines the SourceOS-side office integration profile for the workspace office suite program.
+
+`source-os` is the Linux realization home for host roles, profiles, images, builders, and Linux-facing integration surfaces. This office profile should realize the local and desktop side of the workspace office stack defined in `SocioProphet/prophet-workspace` and the cloud/runtime services defined in `SocioProphet/prophet-platform`.
+
+## SourceOS responsibilities
+
+The Linux and desktop layer should own:
+- LibreOffice defaults and compatibility tuning
+- local office file associations and MIME defaults
+- font substitution and template packaging
+- local office smoke tests and round-trip verification
+- local semantic extraction hooks for documents
+- desktop shell behavior for opening office files and handing off cloud edit sessions when required
+
+## Boundary rule
+
+Shared schemas and canonical runtime vocabulary should stay in upstream product/runtime repositories. `source-os` should realize those contracts as Linux profiles, host roles, and desktop integration.
+
+## Planned filesystem surfaces
+
+- `build/office-suite/`
+- `build/office-suite/profiles/`
+- `configs/libreoffice/`
+- `configs/fontconfig/`
+- `configs/mime/`
+
+## First host profile modes
+
+- `sovereign` — ODF-first local profile
+- `interoperability` — OOXML-friendly local profile
+- `migration` — preserve source format and emit compatibility warnings
+- `cloud` — default behavior for cloud editor handoff and versioned saveback
+
+## Cross-repo integration
+
+### With `prophet-workspace`
+
+Product/domain semantics for docs, sheets, slides, files, collaboration, AI assistance, and workflow agents belong there.
+
+### With `prophet-platform`
+
+Cloud document control, WOPI host behavior, office runtime schemas, AI actions, and workflow runtime belong there.


### PR DESCRIPTION
## Summary

Add the first office integration slice to `source-os`.

Files:
- `docs/SOURCEOS_OFFICE_INTEGRATION_PROFILE.md`
- `build/office-suite/README.md`
- `build/office-suite/profiles/sourceos-office-profile.toml`

## Cross-repo posture

- `prophet-workspace` = product semantics
- `prophet-platform` = cloud/runtime realization
- `source-os` = Linux and desktop realization
