### PR TITLE
workstation-v0: add input-remapper primary lane and fusuma gestures

### DIFF
--- a/docs/workstation/README.md
+++ b/docs/workstation/README.md
@@ -33,6 +33,9 @@ Workflow file:
 - CLI-first developer experience with keyboard-first navigation.
 - GNOME baseline customization via GSettings and pinned extensions (no GNOME core forks).
 - Open-source launcher palette (Wayland-first): `sourceos palette` uses fuzzel (primary) with wofi/rofi fallbacks.
+- Primary keyboard remap lane: `input-remapper` on Fedora/GNOME.
+- Compatibility remap lanes: `xremap` and `kinto` (explicit compatibility path, not default).
+- Touchpad gesture lane: `fusuma`.
 - Local status/doctor surfaces that can be opened from the launcher (`sourceos status --open`, `sourceos doctor --open`).
 
 ## Apply
@@ -64,6 +67,7 @@ Notes:
 
 - Workstation v0 avoids non-open launchers.
 - Launcher install is best-effort via distro packages (Fedora: fuzzel) and does not silently enable third-party repos.
+- Kinto is treated as an explicit compatibility lane rather than the default Wayland-first path.
 
 ## Related docs
 

--- a/profiles/linux-dev/workstation-v0/doctor.sh
+++ b/profiles/linux-dev/workstation-v0/doctor.sh
@@ -160,6 +160,64 @@ check_launcher(){
   record_result error launcher "missing (need fuzzel/wofi/rofi)"
 }
 
+check_input_backend(){
+  if have input-remapper-control; then
+    info "ok: input backend (input-remapper)"
+    record_result ok input-backend "input-remapper"
+    return
+  fi
+  if have xremap; then
+    info "ok: input backend (xremap compatibility)"
+    record_result ok input-backend "xremap"
+    return
+  fi
+  if have xkeysnail; then
+    info "ok: input backend (xkeysnail / kinto compatibility)"
+    record_result ok input-backend "xkeysnail"
+    return
+  fi
+
+  warn "no keyboard remap backend detected (input-remapper/xremap/xkeysnail)"
+  record_result warn input-backend "missing (input-remapper/xremap/xkeysnail)"
+}
+
+check_fusuma_lane(){
+  local cfg="${XDG_CONFIG_HOME:-$HOME/.config}/fusuma/config.yml"
+  local svc="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user/sourceos-fusuma.service"
+
+  if have fusuma; then
+    info "ok: fusuma"
+    record_result ok fusuma "binary present"
+  else
+    warn "fusuma missing"
+    record_result warn fusuma "binary missing"
+  fi
+
+  if [[ -f "$cfg" ]]; then
+    info "ok: fusuma config"
+    record_result ok fusuma-config "$cfg"
+  else
+    warn "fusuma config missing: $cfg"
+    record_result warn fusuma-config "missing"
+  fi
+
+  if [[ -f "$svc" ]]; then
+    info "ok: fusuma user service"
+    record_result ok fusuma-service "$svc"
+  else
+    warn "fusuma user service missing: $svc"
+    record_result warn fusuma-service "missing"
+  fi
+
+  if id -nG "$USER" 2>/dev/null | grep -qw input; then
+    info "ok: user is in input group"
+    record_result ok input-group "present"
+  else
+    warn "user is not in input group (fusuma may lack device access)"
+    record_result warn input-group "missing"
+  fi
+}
+
 main(){
   parse_args "$@"
 
@@ -214,6 +272,8 @@ main(){
   if gnome_detect; then
     record_result info gnome "detected"
     check_launcher
+    check_input_backend
+    check_fusuma_lane
 
     if have gsettings; then
       info "gnome: detected; gsettings present"

--- a/profiles/linux-dev/workstation-v0/gnome/fusuma-apply.sh
+++ b/profiles/linux-dev/workstation-v0/gnome/fusuma-apply.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Apply SourceOS fusuma defaults for workstation-v0.
+# - writes ~/.config/fusuma/config.yml if absent
+# - installs a user systemd service if available
+# - safe to run repeatedly
+
+info(){ printf "INFO: %s\n" "$*" >&2; }
+warn(){ printf "WARN: %s\n" "$*" >&2; }
+
+have(){ command -v "$1" >/dev/null 2>&1; }
+
+is_gnome(){
+  [[ "${XDG_CURRENT_DESKTOP:-}" == *GNOME* ]] && return 0
+  [[ "${DESKTOP_SESSION:-}" == *gnome* ]] && return 0
+  return 1
+}
+
+write_config(){
+  local cfg_dir="${XDG_CONFIG_HOME:-$HOME/.config}/fusuma"
+  local cfg="$cfg_dir/config.yml"
+  mkdir -p "$cfg_dir"
+
+  if [[ -f "$cfg" ]]; then
+    info "fusuma config already present: $cfg"
+    return 0
+  fi
+
+  cat > "$cfg" <<'EOF'
+swipe:
+  3:
+    left:
+      command: "xdotool key alt+Right"
+    right:
+      command: "xdotool key alt+Left"
+    up:
+      command: "xdotool key super"
+    down:
+      command: "xdotool key super"
+  4:
+    left:
+      command: "xdotool key ctrl+alt+Right"
+    right:
+      command: "xdotool key ctrl+alt+Left"
+pinch:
+  2:
+    in:
+      command: "xdotool key ctrl+minus"
+    out:
+      command: "xdotool key ctrl+plus"
+threshold:
+  swipe: 0.8
+  pinch: 0.2
+interval:
+  swipe: 0.6
+  pinch: 0.2
+EOF
+
+  info "wrote fusuma config: $cfg"
+}
+
+write_service(){
+  local svc_dir="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
+  local svc="$svc_dir/sourceos-fusuma.service"
+  mkdir -p "$svc_dir"
+
+  cat > "$svc" <<'EOF'
+[Unit]
+Description=SourceOS Fusuma gestures
+After=graphical-session.target
+PartOf=graphical-session.target
+
+[Service]
+Type=simple
+ExecStart=fusuma
+Restart=on-failure
+RestartSec=2
+
+[Install]
+WantedBy=default.target
+EOF
+
+  info "wrote user service: $svc"
+
+  if have systemctl; then
+    systemctl --user daemon-reload || true
+    systemctl --user enable sourceos-fusuma.service || true
+  fi
+}
+
+main(){
+  if ! is_gnome; then
+    warn "GNOME not detected; skipping fusuma apply"
+    exit 0
+  fi
+
+  write_config
+  write_service
+}
+
+main "$@"

--- a/profiles/linux-dev/workstation-v0/gnome/fusuma-install.sh
+++ b/profiles/linux-dev/workstation-v0/gnome/fusuma-install.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install fusuma and its runtime dependencies for workstation-v0.
+# Fedora lane follows upstream guidance:
+# - libinput
+# - ruby
+# - xdotool (for shortcut dispatch)
+# - gem install fusuma
+# - membership in input group
+
+info(){ printf "INFO: %s\n" "$*" >&2; }
+warn(){ printf "WARN: %s\n" "$*" >&2; }
+err(){ printf "ERROR: %s\n" "$*" >&2; }
+
+have(){ command -v "$1" >/dev/null 2>&1; }
+
+is_gnome(){
+  [[ "${XDG_CURRENT_DESKTOP:-}" == *GNOME* ]] && return 0
+  [[ "${DESKTOP_SESSION:-}" == *gnome* ]] && return 0
+  return 1
+}
+
+os_id(){
+  if [[ -r /etc/os-release ]]; then
+    . /etc/os-release
+    printf '%s\n' "${ID:-linux}"
+  else
+    printf '%s\n' linux
+  fi
+}
+
+install_pkg_fedora(){
+  if have rpm-ostree; then
+    sudo rpm-ostree install "$@" || true
+    return
+  fi
+  if have dnf; then
+    sudo dnf install -y "$@" || true
+    return
+  fi
+}
+
+main(){
+  if ! is_gnome; then
+    warn "GNOME not detected; skipping fusuma install"
+    exit 0
+  fi
+
+  local id
+  id="$(os_id)"
+  if [[ "$id" != "fedora" ]]; then
+    warn "Unsupported distro for packaged fusuma dependency install (id=$id)"
+    exit 0
+  fi
+
+  info "Installing fusuma dependencies"
+  install_pkg_fedora libinput ruby xdotool
+
+  if have gem; then
+    if have fusuma; then
+      info "fusuma already installed"
+    else
+      sudo gem install fusuma || true
+    fi
+  else
+    warn "gem not found after ruby install; skipping fusuma gem install"
+  fi
+
+  if getent group input >/dev/null 2>&1; then
+    sudo gpasswd -a "$USER" input || true
+    warn "Added $USER to input group (if not already). New login may be required."
+  else
+    warn "input group not found; fusuma may lack device access"
+  fi
+}
+
+main "$@"

--- a/profiles/linux-dev/workstation-v0/gnome/input-install.sh
+++ b/profiles/linux-dev/workstation-v0/gnome/input-install.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install keyboard remap backend(s) for workstation-v0.
+# Strategy:
+# - Primary (Fedora/Wayland/GNOME): input-remapper
+# - Compatibility assets: xremap template (MIT) for advanced per-app remapping
+# - Kinto is treated as an X11 compatibility lane and is NOT auto-installed here
+#
+# Env:
+# - SOURCEOS_REMAP_BACKEND=input-remapper|xremap|kinto (default: input-remapper)
+
+info(){ printf "INFO: %s\n" "$*" >&2; }
+warn(){ printf "WARN: %s\n" "$*" >&2; }
+err(){ printf "ERROR: %s\n" "$*" >&2; }
+
+have(){ command -v "$1" >/dev/null 2>&1; }
+
+backend(){
+  printf '%s\n' "${SOURCEOS_REMAP_BACKEND:-input-remapper}"
+}
+
+is_gnome(){
+  [[ "${XDG_CURRENT_DESKTOP:-}" == *GNOME* ]] && return 0
+  [[ "${DESKTOP_SESSION:-}" == *gnome* ]] && return 0
+  return 1
+}
+
+os_id(){
+  if [[ -r /etc/os-release ]]; then
+    . /etc/os-release
+    printf '%s\n' "${ID:-linux}"
+  else
+    printf '%s\n' linux
+  fi
+}
+
+install_pkg_fedora(){
+  local pkg=$1
+  if have rpm-ostree; then
+    sudo rpm-ostree install "$pkg" || true
+    return
+  fi
+  if have dnf; then
+    sudo dnf install -y "$pkg" || true
+    return
+  fi
+}
+
+write_xremap_template(){
+  local dst_dir="${XDG_CONFIG_HOME:-$HOME/.config}/sourceos/input"
+  mkdir -p "$dst_dir"
+  cat > "$dst_dir/xremap-macos-compat.yml" <<'EOF'
+# SourceOS xremap compatibility template
+# Intended for GNOME Wayland/X11 advanced remapping.
+# Apply manually if you choose the xremap compatibility lane.
+modmap:
+  - name: SourceOS mac-like modifiers
+    remap:
+      CapsLock: Esc
+      Control_L: Super_L
+      Super_L: Alt_L
+      Alt_L: Control_L
+      Control_R: Super_R
+      Super_R: Alt_R
+      Alt_R: Control_R
+EOF
+  info "wrote xremap compatibility template: $dst_dir/xremap-macos-compat.yml"
+}
+
+main(){
+  if ! is_gnome; then
+    warn "GNOME not detected; skipping input backend install"
+    exit 0
+  fi
+
+  local b
+  b="$(backend)"
+  case "$b" in
+    input-remapper)
+      local id
+      id="$(os_id)"
+      if [[ "$id" == "fedora" ]]; then
+        info "Installing primary remap backend: input-remapper"
+        install_pkg_fedora input-remapper
+      else
+        warn "Unsupported distro for primary packaged input-remapper install (id=$id)"
+      fi
+      write_xremap_template
+      ;;
+    xremap)
+      warn "xremap compatibility lane selected; not auto-installing binary in this profile"
+      write_xremap_template
+      ;;
+    kinto)
+      warn "Kinto compatibility lane selected; not auto-installing in Wayland-first profile"
+      warn "Kinto depends on xkeysnail/X11 and is treated as an explicit compatibility path"
+      write_xremap_template
+      ;;
+    *)
+      err "unknown SOURCEOS_REMAP_BACKEND=$b"
+      exit 2
+      ;;
+  esac
+}
+
+main "$@"

--- a/profiles/linux-dev/workstation-v0/install.sh
+++ b/profiles/linux-dev/workstation-v0/install.sh
@@ -87,7 +87,6 @@ patch_shell_rc_if_enabled(){
     return 0
   fi
 
-  # Fallback for partial installs.
   local sh_script="$PROFILE_DIR/bin/patch-shell.sh"
   if [[ -x "$sh_script" ]]; then
     info "Autopatch enabled: patching shell rc files"
@@ -123,6 +122,36 @@ apply_gnome_extensions(){
   fi
 }
 
+apply_input_install(){
+  local script="$PROFILE_DIR/gnome/input-install.sh"
+  if [[ -x "$script" ]]; then
+    info "Installing input remap lane (best-effort)"
+    "$script" || warn "input lane install failed (non-fatal)"
+  else
+    warn "input install script not found: $script"
+  fi
+}
+
+apply_fusuma_install(){
+  local script="$PROFILE_DIR/gnome/fusuma-install.sh"
+  if [[ -x "$script" ]]; then
+    info "Installing fusuma gesture lane (best-effort)"
+    "$script" || warn "fusuma install failed (non-fatal)"
+  else
+    warn "fusuma install script not found: $script"
+  fi
+}
+
+apply_fusuma_config(){
+  local script="$PROFILE_DIR/gnome/fusuma-apply.sh"
+  if [[ -x "$script" ]]; then
+    info "Applying fusuma defaults (best-effort)"
+    "$script" || warn "fusuma apply failed (non-fatal)"
+  else
+    warn "fusuma apply script not found: $script"
+  fi
+}
+
 apply_launcher_install(){
   local script="$PROFILE_DIR/gnome/launcher-install.sh"
   if [[ -x "$script" ]]; then
@@ -152,6 +181,9 @@ main(){
   patch_shell_rc_if_enabled
   apply_gnome_baseline
   apply_gnome_extensions
+  apply_input_install
+  apply_fusuma_install
+  apply_fusuma_config
   apply_launcher_install
   apply_palette_hotkey
   info "installed workstation-v0 (linux-dev)"

--- a/profiles/linux-dev/workstation-v0/manifest.yaml
+++ b/profiles/linux-dev/workstation-v0/manifest.yaml
@@ -14,8 +14,8 @@ spec:
         - wl-clipboard
         - jq
         - xclip
-        # launcher (Wayland-first)
         - fuzzel
+        - input-remapper
       dnf:
         - git
         - openssh-clients
@@ -24,8 +24,8 @@ spec:
         - wl-clipboard
         - jq
         - xclip
-        # launcher (Wayland-first)
         - fuzzel
+        - input-remapper
     user:
       brew:
         - fzf
@@ -70,12 +70,18 @@ spec:
   desktop:
     gnome:
       inputs:
-        kinto:
+        primary_backend:
+          name: input-remapper
+          rationale: "Packaged on Fedora and works across X11/Wayland at evdev layer"
+        compatibility_backends:
+          - name: xremap
+            rationale: "MIT, app-specific remapping, GNOME Wayland compatible"
+          - name: kinto
+            rationale: "X11/xkeysnail compatibility lane for mac-style shortcuts"
+        gestures:
+          name: fusuma
           enabled: true
-          note: "X11-centric; validate Wayland or use keyd/xremap"
-        fusuma:
-          enabled: true
-          note: "libinput gestures; validate hardware"
+          rationale: "MIT multitouch gesture recognizer using libinput"
   launcher:
     palette:
       primary: fuzzel


### PR DESCRIPTION
Implements the next substantial workstation-v0 slice: input remapping and touchpad gestures.

Changes:
- `profiles/linux-dev/workstation-v0/gnome/input-install.sh`
  - primary remap backend install lane for Fedora/GNOME: `input-remapper`
  - writes xremap compatibility template for advanced/manual use
  - treats Kinto as an explicit compatibility lane rather than default auto-install
- `profiles/linux-dev/workstation-v0/gnome/fusuma-install.sh`
  - installs fusuma dependencies on Fedora (`libinput`, `ruby`, `xdotool`)
  - installs the `fusuma` gem
  - adds the current user to the `input` group
- `profiles/linux-dev/workstation-v0/gnome/fusuma-apply.sh`
  - writes SourceOS default `~/.config/fusuma/config.yml`
  - writes `~/.config/systemd/user/sourceos-fusuma.service`
  - best-effort enables the user service
- `profiles/linux-dev/workstation-v0/install.sh`
  - integrates input install + fusuma install/apply into the main workstation flow
- `profiles/linux-dev/workstation-v0/doctor.sh`
  - validates presence of an input backend (`input-remapper` / `xremap` / `xkeysnail` compatibility)
  - validates fusuma binary/config/service/input-group state
- `profiles/linux-dev/workstation-v0/manifest.yaml`
  - clarifies primary backend (`input-remapper`), compatibility backends (`xremap`, `kinto`), and fusuma gesture lane
- `docs/workstation/README.md`
  - updates the workstation goals/trust-boundary text for the new input/gesture lanes

Why:
- We were strong on CLI/report/operator substrate but weak on actual desktop input/gesture realization.
- This PR starts closing that gap with a real Fedora/GNOME implementation lane.

Notes:
- `input-remapper` is the default packaged path for Fedora/GNOME.
- `xremap` and `kinto` are treated as compatibility lanes, not the default path.
- Fusuma is installed/applied best-effort; service enablement is non-fatal.
