### PR TITLE
build(source-os): add office host config and smoke helpers

### DIFF
--- a/build/office-suite/scripts/extract_office_semantic_units.sh
+++ b/build/office-suite/scripts/extract_office_semantic_units.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "usage: $0 <office-file>" >&2
+  exit 1
+fi
+
+INPUT="$1"
+if [[ ! -f "$INPUT" ]]; then
+  echo "missing input: $INPUT" >&2
+  exit 1
+fi
+
+EXT="${INPUT##*.}"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+case "$EXT" in
+  odt|docx|doc|rtf)
+    if ! command -v soffice >/dev/null 2>&1; then
+      echo "soffice not found" >&2
+      exit 1
+    fi
+    soffice --headless --convert-to txt:Text --outdir "$TMPDIR" "$INPUT" >/dev/null 2>&1 || {
+      echo "LibreOffice extraction failed" >&2
+      exit 1
+    }
+    TXT_OUT="$TMPDIR/$(basename "${INPUT%.*}").txt"
+    if [[ ! -f "$TXT_OUT" ]]; then
+      echo "missing extracted text output" >&2
+      exit 1
+    fi
+    cat "$TXT_OUT"
+    ;;
+  txt|md)
+    cat "$INPUT"
+    ;;
+  *)
+    echo "unsupported extension for local extraction: $EXT" >&2
+    exit 2
+    ;;
+esac

--- a/build/office-suite/scripts/office_cloud_handoff.sh
+++ b/build/office-suite/scripts/office_cloud_handoff.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "usage: $0 <office-file>" >&2
+  exit 1
+fi
+
+INPUT="$1"
+if [[ ! -f "$INPUT" ]]; then
+  echo "missing input: $INPUT" >&2
+  exit 1
+fi
+
+BASE_URL="${SOURCEOS_OFFICE_CLOUD_BASE_URL:-http://127.0.0.1:8080}"
+ENCODED_PATH="$(python3 - <<'PY' "$INPUT"
+import sys, urllib.parse
+print(urllib.parse.quote(sys.argv[1]))
+PY
+)"
+TARGET="${BASE_URL}/open?path=${ENCODED_PATH}"
+
+if command -v xdg-open >/dev/null 2>&1; then
+  xdg-open "$TARGET" >/dev/null 2>&1 || true
+fi
+
+echo "$TARGET"

--- a/build/office-suite/scripts/office_extract_smoke.sh
+++ b/build/office-suite/scripts/office_extract_smoke.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+TEMPLATE="$ROOT/build/office-suite/templates/sovereign/sourceos-default-writer.fodt"
+EXTRACTOR="$ROOT/build/office-suite/scripts/extract_office_semantic_units.sh"
+
+if [[ ! -f "$TEMPLATE" ]]; then
+  echo "missing template: $TEMPLATE" >&2
+  exit 1
+fi
+
+if [[ ! -x "$EXTRACTOR" ]]; then
+  chmod +x "$EXTRACTOR" 2>/dev/null || true
+fi
+
+if ! command -v soffice >/dev/null 2>&1; then
+  echo "soffice not found; skipping extraction smoke" >&2
+  exit 0
+fi
+
+OUT="$($EXTRACTOR "$TEMPLATE")"
+[[ "$OUT" == *"SourceOS sovereign writer template placeholder."* ]] || {
+  echo "extraction smoke failed" >&2
+  exit 1
+}
+
+echo "office extraction smoke passed"

--- a/build/office-suite/scripts/office_open.sh
+++ b/build/office-suite/scripts/office_open.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "usage: $0 <office-file>" >&2
+  exit 1
+fi
+
+INPUT="$1"
+if [[ ! -f "$INPUT" ]]; then
+  echo "missing input: $INPUT" >&2
+  exit 1
+fi
+
+MODE="${SOURCEOS_OFFICE_MODE:-local}"
+
+case "$MODE" in
+  cloud)
+    "$(dirname "$0")/office_cloud_handoff.sh" "$INPUT"
+    ;;
+  local|sovereign|interoperability|migration)
+    if ! command -v soffice >/dev/null 2>&1; then
+      echo "soffice not found" >&2
+      exit 1
+    fi
+    soffice "$INPUT" >/dev/null 2>&1 || true
+    echo "$INPUT"
+    ;;
+  *)
+    echo "unknown SOURCEOS_OFFICE_MODE: $MODE" >&2
+    exit 2
+    ;;
+esac

--- a/build/office-suite/scripts/office_open_smoke.sh
+++ b/build/office-suite/scripts/office_open_smoke.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+TEST_DOC="$TMPDIR/smoke.txt"
+echo "SourceOS office open smoke" > "$TEST_DOC"
+
+# Cloud mode should return a handoff URL.
+CLOUD_OUT="$(SOURCEOS_OFFICE_MODE=cloud "$ROOT/build/office-suite/scripts/office_open.sh" "$TEST_DOC")"
+case "$CLOUD_OUT" in
+  http://*|https://*) ;;
+  *)
+    echo "cloud handoff smoke failed" >&2
+    exit 1
+    ;;
+esac
+
+# Local mode smoke only checks that the helper accepts the path and returns it.
+# `soffice` availability is still enforced by the helper itself.
+if command -v soffice >/dev/null 2>&1; then
+  LOCAL_OUT="$(SOURCEOS_OFFICE_MODE=local "$ROOT/build/office-suite/scripts/office_open.sh" "$TEST_DOC")"
+  [[ "$LOCAL_OUT" == "$TEST_DOC" ]] || {
+    echo "local open smoke failed" >&2
+    exit 1
+  }
+fi
+
+echo "office open smoke passed"

--- a/build/office-suite/scripts/office_roundtrip_smoke.sh
+++ b/build/office-suite/scripts/office_roundtrip_smoke.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v soffice >/dev/null 2>&1; then
+  echo "soffice not found" >&2
+  exit 1
+fi
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+cat > "$TMPDIR/smoke.odt" <<'EOF'
+This is a SourceOS office roundtrip smoke placeholder.
+EOF
+
+# Convert via LibreOffice headless as a smoke path.
+soffice --headless --convert-to pdf --outdir "$TMPDIR" "$TMPDIR/smoke.odt" >/dev/null 2>&1 || {
+  echo "LibreOffice headless conversion failed" >&2
+  exit 1
+}
+
+if [[ ! -f "$TMPDIR/smoke.pdf" ]]; then
+  echo "roundtrip smoke failed: missing PDF output" >&2
+  exit 1
+fi
+
+echo "office roundtrip smoke passed"

--- a/build/office-suite/scripts/office_search_handoff.sh
+++ b/build/office-suite/scripts/office_search_handoff.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "usage: $0 <query>" >&2
+  exit 1
+fi
+
+QUERY="$1"
+
+if command -v lampstand >/dev/null 2>&1; then
+  lampstand query "$QUERY" --limit 10 || true
+  exit 0
+fi
+
+SOCKET="${XDG_RUNTIME_DIR:-/tmp}/lampstand.sock"
+if [[ -S "$SOCKET" ]]; then
+  printf '{"method":"query","query":"%s","limit":10}\n' "$QUERY" | socat - UNIX-CONNECT:"$SOCKET" || true
+  exit 0
+fi
+
+echo "lampstand not available" >&2
+exit 2

--- a/build/office-suite/scripts/verify_office_suite_profile.sh
+++ b/build/office-suite/scripts/verify_office_suite_profile.sh
@@ -22,6 +22,7 @@ require_file "build/office-suite/templates/sovereign/sourceos-default-writer.fod
 require_file "build/office-suite/scripts/office_cloud_handoff.sh"
 require_file "build/office-suite/scripts/office_open.sh"
 require_file "build/office-suite/scripts/office_open_smoke.sh"
+require_file "build/office-suite/scripts/office_extract_smoke.sh"
 
 if [[ $FAIL -ne 0 ]]; then
   echo "office suite profile verification failed" >&2

--- a/build/office-suite/scripts/verify_office_suite_profile.sh
+++ b/build/office-suite/scripts/verify_office_suite_profile.sh
@@ -21,6 +21,7 @@ require_file "configs/mime/sourceos-office-mimeapps.list"
 require_file "build/office-suite/templates/sovereign/sourceos-default-writer.fodt"
 require_file "build/office-suite/scripts/office_cloud_handoff.sh"
 require_file "build/office-suite/scripts/office_open.sh"
+require_file "build/office-suite/scripts/office_open_smoke.sh"
 
 if [[ $FAIL -ne 0 ]]; then
   echo "office suite profile verification failed" >&2

--- a/build/office-suite/scripts/verify_office_suite_profile.sh
+++ b/build/office-suite/scripts/verify_office_suite_profile.sh
@@ -23,6 +23,7 @@ require_file "build/office-suite/scripts/office_cloud_handoff.sh"
 require_file "build/office-suite/scripts/office_open.sh"
 require_file "build/office-suite/scripts/office_open_smoke.sh"
 require_file "build/office-suite/scripts/office_extract_smoke.sh"
+require_file "build/office-suite/scripts/office_search_handoff.sh"
 
 if [[ $FAIL -ne 0 ]]; then
   echo "office suite profile verification failed" >&2

--- a/build/office-suite/scripts/verify_office_suite_profile.sh
+++ b/build/office-suite/scripts/verify_office_suite_profile.sh
@@ -18,6 +18,8 @@ require_file "build/office-suite/profiles/sourceos-office-profile.toml"
 require_file "configs/libreoffice/sourceos-office.xcu"
 require_file "configs/fontconfig/office-font-substitutions.conf"
 require_file "configs/mime/sourceos-office-mimeapps.list"
+require_file "build/office-suite/templates/sovereign/sourceos-default-writer.fodt"
+require_file "build/office-suite/scripts/office_cloud_handoff.sh"
 
 if [[ $FAIL -ne 0 ]]; then
   echo "office suite profile verification failed" >&2

--- a/build/office-suite/scripts/verify_office_suite_profile.sh
+++ b/build/office-suite/scripts/verify_office_suite_profile.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+FAIL=0
+
+require_file() {
+  local path="$1"
+  if [[ ! -f "$ROOT/$path" ]]; then
+    echo "missing: $path" >&2
+    FAIL=1
+  else
+    echo "ok: $path"
+  fi
+}
+
+require_file "build/office-suite/profiles/sourceos-office-profile.toml"
+require_file "configs/libreoffice/sourceos-office.xcu"
+require_file "configs/fontconfig/office-font-substitutions.conf"
+require_file "configs/mime/sourceos-office-mimeapps.list"
+
+if [[ $FAIL -ne 0 ]]; then
+  echo "office suite profile verification failed" >&2
+  exit 1
+fi
+
+echo "office suite profile verification passed"

--- a/build/office-suite/scripts/verify_office_suite_profile.sh
+++ b/build/office-suite/scripts/verify_office_suite_profile.sh
@@ -20,6 +20,7 @@ require_file "configs/fontconfig/office-font-substitutions.conf"
 require_file "configs/mime/sourceos-office-mimeapps.list"
 require_file "build/office-suite/templates/sovereign/sourceos-default-writer.fodt"
 require_file "build/office-suite/scripts/office_cloud_handoff.sh"
+require_file "build/office-suite/scripts/office_open.sh"
 
 if [[ $FAIL -ne 0 ]]; then
   echo "office suite profile verification failed" >&2

--- a/build/office-suite/templates/README.md
+++ b/build/office-suite/templates/README.md
@@ -1,0 +1,11 @@
+# SourceOS Office Template Pack
+
+This directory is the template-pack layout for the SourceOS office suite.
+
+Planned contents:
+- sovereign/default templates for ODF-first workflows
+- interoperability templates for OOXML-heavy workflows
+- migration templates for warning-driven onboarding
+- cloud handoff templates for browser/editor transitions
+
+This layout is intentionally host-oriented. Product semantics belong in `SocioProphet/prophet-workspace`, while cloud/runtime services belong in `SocioProphet/prophet-platform`.

--- a/build/office-suite/templates/sovereign/sourceos-default-writer.fodt
+++ b/build/office-suite/templates/sovereign/sourceos-default-writer.fodt
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<office:document xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" office:version="1.3">
+  <office:meta/>
+  <office:body>
+    <office:text>
+      <text:p>SourceOS sovereign writer template placeholder.</text:p>
+    </office:text>
+  </office:body>
+</office:document>

--- a/configs/fontconfig/office-font-substitutions.conf
+++ b/configs/fontconfig/office-font-substitutions.conf
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<!DOCTYPE fontconfig SYSTEM "fonts.dtd">
+<fontconfig>
+  <alias>
+    <family>Calibri</family>
+    <prefer><family>Carlito</family></prefer>
+  </alias>
+  <alias>
+    <family>Cambria</family>
+    <prefer><family>Caladea</family></prefer>
+  </alias>
+  <alias>
+    <family>Arial</family>
+    <prefer><family>Liberation Sans</family></prefer>
+  </alias>
+  <alias>
+    <family>Times New Roman</family>
+    <prefer><family>Liberation Serif</family></prefer>
+  </alias>
+  <alias>
+    <family>Courier New</family>
+    <prefer><family>Liberation Mono</family></prefer>
+  </alias>
+</fontconfig>

--- a/configs/libreoffice/sourceos-office.xcu
+++ b/configs/libreoffice/sourceos-office.xcu
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<oor:items xmlns:oor="http://openoffice.org/2001/registry">
+  <item oor:path="/org.openoffice.Office.Common/Save/Document">
+    <prop oor:name="WarnAlienFormat" oor:op="fuse">
+      <value>true</value>
+    </prop>
+  </item>
+  <item oor:path="/org.openoffice.Office.Common/Misc">
+    <prop oor:name="UseSystemFileDialog" oor:op="fuse">
+      <value>true</value>
+    </prop>
+  </item>
+  <item oor:path="/org.openoffice.Office.Paths/Current">
+    <prop oor:name="Template" oor:op="fuse">
+      <value>$(user)/templates;$(inst)/share/templates/sourceos</value>
+    </prop>
+  </item>
+  <item oor:path="/org.openoffice.Office.Common/Filter/Microsoft">
+    <prop oor:name="ImportMathTypeAsMath" oor:op="fuse">
+      <value>true</value>
+    </prop>
+  </item>
+</oor:items>

--- a/configs/mime/sourceos-office-mimeapps.list
+++ b/configs/mime/sourceos-office-mimeapps.list
@@ -1,0 +1,11 @@
+[Default Applications]
+application/vnd.oasis.opendocument.text=libreoffice-writer.desktop
+application/vnd.oasis.opendocument.spreadsheet=libreoffice-calc.desktop
+application/vnd.oasis.opendocument.presentation=libreoffice-impress.desktop
+application/vnd.openxmlformats-officedocument.wordprocessingml.document=libreoffice-writer.desktop
+application/vnd.openxmlformats-officedocument.spreadsheetml.sheet=libreoffice-calc.desktop
+application/vnd.openxmlformats-officedocument.presentationml.presentation=libreoffice-impress.desktop
+application/msword=libreoffice-writer.desktop
+application/vnd.ms-excel=libreoffice-calc.desktop
+application/vnd.ms-powerpoint=libreoffice-impress.desktop
+application/pdf=org.gnome.Evince.desktop


### PR DESCRIPTION
## Summary

Add the next office host slice to `source-os`.

Files:
- `configs/libreoffice/sourceos-office.xcu`
- `configs/fontconfig/office-font-substitutions.conf`
- `configs/mime/sourceos-office-mimeapps.list`
- `build/office-suite/scripts/verify_office_suite_profile.sh`
- `build/office-suite/scripts/office_roundtrip_smoke.sh`

## Cross-repo posture

- `prophet-workspace` = product semantics
- `prophet-platform` = cloud/runtime realization
- `source-os` = Linux and desktop realization
