### PR TITLE
runtime: add sourceos-shell contract test and launcher bridge note

### DIFF
--- a/docs/sourceos-shell-launcher-bridge.md
+++ b/docs/sourceos-shell-launcher-bridge.md
@@ -1,0 +1,19 @@
+# sourceos-shell launcher bridge note
+
+During the early shell rollout, launcher integration is tracked as temporary bridge work.
+
+## Routing rule
+
+Queries are routed by scope:
+
+- `apps` -> launcher or desktop-entry provider
+- `files` -> Linux-native file search only
+- `web` -> browser or web agent
+
+## Required invariant
+
+For `files` queries, Albert must not perform a second file-search pass in parallel with the Linux-native provider.
+
+## Lifecycle
+
+This bridge exists only until the shell's own command/search surface fully absorbs the routing behavior.

--- a/flake.nix
+++ b/flake.nix
@@ -65,6 +65,8 @@
             else pkgs.runCommand "stable-x86_64-smoke-skip" {} ''
               mkdir -p $out
             '';
+
+          sourceos-shell-module-contract = import ./tests/sourceos-shell-module-contract.nix { inherit pkgs; };
         });
 
       sourceos = {

--- a/profiles/linux-dev/default.nix
+++ b/profiles/linux-dev/default.nix
@@ -2,6 +2,7 @@
 {
   imports = [
     ../../modules/build/default.nix
+    ../../profiles/linux-dev/sourceos-shell.nix
   ];
 
   sourceos.build = {

--- a/tests/sourceos-shell-module-contract.nix
+++ b/tests/sourceos-shell-module-contract.nix
@@ -1,0 +1,15 @@
+{ pkgs ? import <nixpkgs> {} }:
+pkgs.runCommand "sourceos-shell-module-contract" {
+  nativeBuildInputs = [ pkgs.gnugrep ];
+} ''
+  test -f ${../modules/nixos/sourceos-shell/default.nix}
+  test -f ${../profiles/linux-dev/sourceos-shell.nix}
+  test -f ${../linux/desktop/sourceos-shell.desktop}
+  test -f ${../linux/systemd/sourceos-shell.service}
+  test -f ${../linux/systemd/sourceos-router.service}
+  test -f ${../linux/systemd/sourceos-pdf-secure.service}
+  grep -q '../../modules/nixos/sourceos-shell/default.nix' ${../profiles/linux-dev/sourceos-shell.nix}
+  grep -q 'sourceos.shell' ${../modules/nixos/sourceos-shell/default.nix}
+  mkdir -p $out
+  echo validated > $out/result.txt
+''


### PR DESCRIPTION
## Summary

Stacked on top of the initial Linux bootstrap for `sourceos-shell`, this PR adds the first contract-style test scaffold, wires the linux-dev profile to import the shell profile scaffold, adds a flake check, and documents the temporary launcher bridge rule.

## Added files

- `tests/sourceos-shell-module-contract.nix`
- `docs/sourceos-shell-launcher-bridge.md`

## Updated files

- `profiles/linux-dev/default.nix`
- `flake.nix`

## Why

The initial Linux bootstrap PR adds module/profile/desktop/service scaffolds. This follow-on PR starts enforcing those surfaces with a test and records the launcher-routing invariant:

- `apps` -> launcher provider
- `files` -> Linux-native file search only
- `web` -> browser/web agent

with **no redundant file search** for `files` queries.

## Stack relationship

This PR is stacked on top of:
- `source-os#26`

## Follow-on

- replace placeholder service commands with real shell/router/pdf-secure packages
- add additional integration tests for service graph and desktop entry installation
- land Albert bridge code or patches tracked in issue `#16`
