### PR TITLE
runtime: add sourceos-docd Linux service scaffold

### DIFF
--- a/docs/sourceos-shell-integration.md
+++ b/docs/sourceos-shell-integration.md
@@ -11,6 +11,7 @@ This repository, `source-os`, carries the Linux realization surfaces required to
 - Nix/NixOS modules
 - profile wiring
 - machine-level integration hooks
+- derive-service runtime integration such as `docd`
 
 ## What does not belong here
 

--- a/linux/systemd/sourceos-docd.service
+++ b/linux/systemd/sourceos-docd.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=SourceOS docd derive service
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/opt/sourceos-shell/bin/sourceos-docd
+Restart=on-failure
+RestartSec=2s
+
+[Install]
+WantedBy=multi-user.target

--- a/modules/nixos/sourceos-shell/default.nix
+++ b/modules/nixos/sourceos-shell/default.nix
@@ -73,5 +73,14 @@ in
         ExecStart = "${pkgs.coreutils}/bin/echo sourceos-pdf-secure placeholder port=${toString cfg.pdfSecurePort}";
       };
     };
+
+    systemd.services.sourceos-docd = {
+      description = "SourceOS shell docd scaffold";
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        Type = "simple";
+        ExecStart = "${pkgs.coreutils}/bin/echo sourceos-docd placeholder port=${toString cfg.docdPort}";
+      };
+    };
   };
 }

--- a/tests/sourceos-shell-module-contract.nix
+++ b/tests/sourceos-shell-module-contract.nix
@@ -8,8 +8,10 @@ pkgs.runCommand "sourceos-shell-module-contract" {
   test -f ${../linux/systemd/sourceos-shell.service}
   test -f ${../linux/systemd/sourceos-router.service}
   test -f ${../linux/systemd/sourceos-pdf-secure.service}
+  test -f ${../linux/systemd/sourceos-docd.service}
   grep -q '../../modules/nixos/sourceos-shell/default.nix' ${../profiles/linux-dev/sourceos-shell.nix}
   grep -q 'sourceos.shell' ${../modules/nixos/sourceos-shell/default.nix}
+  grep -q 'sourceos-docd' ${../modules/nixos/sourceos-shell/default.nix}
   mkdir -p $out
   echo validated > $out/result.txt
 ''


### PR DESCRIPTION
## Summary

Stacked on top of the sourceos-shell Linux bootstrap and test/bridge PRs, this PR adds the `sourceos-docd` Linux service scaffold and extends the existing contract-style test to cover it.

## Added files

- `linux/systemd/sourceos-docd.service`

## Updated files

- `modules/nixos/sourceos-shell/default.nix`
- `tests/sourceos-shell-module-contract.nix`
- `docs/sourceos-shell-integration.md`

## Why

The shell lane already includes service scaffolds for shell, router, and pdf-secure. The derive lane (`docd`) is part of the same runtime surface and should be represented in the Linux realization so the service graph is complete.

## Changes

- adds `systemd.services.sourceos-docd` to the `sourceos.shell` module scaffold
- adds a systemd unit file scaffold under `linux/systemd/`
- extends the sourceos-shell module contract test to assert the docd scaffold exists
- updates the integration note to mention derive-service runtime integration

## Stack relationship

This PR is stacked on top of:
- `source-os#26`
- `source-os#70`

## Follow-on

- replace placeholder ExecStart with real package paths once `SourceOS-Linux/sourceos-shell` exists
- extend service graph checks beyond file existence
- bind docd into the eventual shell package/module output
