### PR TITLE
runtime: add sourceos-shell search-provider scaffold and invariant config

### DIFF
--- a/docs/sourceos-shell-launcher-bridge.md
+++ b/docs/sourceos-shell-launcher-bridge.md
@@ -14,6 +14,15 @@ Queries are routed by scope:
 
 For `files` queries, Albert must not perform a second file-search pass in parallel with the Linux-native provider.
 
+## Realization scaffolds
+
+The Linux realization currently carries placeholder search-provider material at:
+
+- `linux/desktop/sourceos-search-provider.conf`
+- `/etc/sourceos-shell/search-provider.json` (realized by the shell Nix module scaffold)
+
+These capture the intended rollout mode and the provider choice for the Linux-native file search lane.
+
 ## Lifecycle
 
 This bridge exists only until the shell's own command/search surface fully absorbs the routing behavior.

--- a/docs/sourceos-shell-launcher-bridge.md
+++ b/docs/sourceos-shell-launcher-bridge.md
@@ -1,6 +1,6 @@
-# sourceos-shell launcher bridge note
+# sourceos-shell command bus note
 
-During the early shell rollout, launcher integration is tracked as temporary bridge work.
+During the early shell rollout, launcher/search integration is tracked as temporary command-bus work.
 
 ## Routing rule
 
@@ -12,7 +12,9 @@ Queries are routed by scope:
 
 ## Required invariant
 
-For `files` queries, Albert must not perform a second file-search pass in parallel with the Linux-native provider.
+For `files` queries, the command bus must not perform a second file-search pass in parallel with the Linux-native provider.
+
+Lampstand is the intended Linux-native file authority for this lane.
 
 ## Realization scaffolds
 
@@ -21,8 +23,8 @@ The Linux realization currently carries placeholder search-provider material at:
 - `linux/desktop/sourceos-search-provider.conf`
 - `/etc/sourceos-shell/search-provider.json` (realized by the shell Nix module scaffold)
 
-These capture the intended rollout mode and the provider choice for the Linux-native file search lane.
+These capture the intended rollout mode, routing invariant, and the provider choice for the Linux-native file search lane.
 
 ## Lifecycle
 
-This bridge exists only until the shell's own command/search surface fully absorbs the routing behavior.
+This command-bus/search-provider surface exists only until the shell's own command/search runtime fully absorbs the routing behavior.

--- a/linux/desktop/sourceos-search-provider.conf
+++ b/linux/desktop/sourceos-search-provider.conf
@@ -1,0 +1,11 @@
+# SourceOS shell search-provider scaffold
+# This file records the intended launcher/search routing policy during early shell rollout.
+
+mode=launcher-bridge
+linux-file-provider=tracker3
+invariant=no_redundant_file_search
+
+# scopes
+apps=launcher
+files=linux-native-only
+web=browser-agent

--- a/linux/desktop/sourceos-search-provider.conf
+++ b/linux/desktop/sourceos-search-provider.conf
@@ -1,7 +1,7 @@
 # SourceOS shell search-provider scaffold
-# This file records the intended launcher/search routing policy during early shell rollout.
+# This file records the intended command-bus/search routing policy during early shell rollout.
 
-mode=launcher-bridge
+mode=command-bus
 linux-file-provider=lampstand
 invariant=no_redundant_file_search
 
@@ -12,4 +12,4 @@ web=browser-agent
 
 # notes
 # - Lampstand is the Linux-native file authority for scope=files.
-# - The launcher remains an action bus and must not perform a second file-search pass.
+# - The command bus remains a frontend and must not perform a second file-search pass.

--- a/linux/desktop/sourceos-search-provider.conf
+++ b/linux/desktop/sourceos-search-provider.conf
@@ -2,10 +2,14 @@
 # This file records the intended launcher/search routing policy during early shell rollout.
 
 mode=launcher-bridge
-linux-file-provider=tracker3
+linux-file-provider=lampstand
 invariant=no_redundant_file_search
 
 # scopes
 apps=launcher
 files=linux-native-only
 web=browser-agent
+
+# notes
+# - Lampstand is the Linux-native file authority for scope=files.
+# - The launcher remains an action bus and must not perform a second file-search pass.

--- a/modules/nixos/sourceos-shell/default.nix
+++ b/modules/nixos/sourceos-shell/default.nix
@@ -38,8 +38,8 @@ in
 
     searchProvider = {
       mode = lib.mkOption {
-        type = lib.types.enum [ "linux-native" "launcher-bridge" "shell-native" ];
-        default = "launcher-bridge";
+        type = lib.types.enum [ "linux-native" "command-bus" "shell-native" ];
+        default = "command-bus";
         description = "Search routing mode during shell rollout.";
       };
 
@@ -74,7 +74,7 @@ in
       };
       notes = [
         "Lampstand is the Linux-native file authority for scope=files."
-        "The launcher remains an action bus and must not perform a second file-search pass."
+        "The command bus remains a frontend and must not perform a second file-search pass."
       ];
     };
 

--- a/modules/nixos/sourceos-shell/default.nix
+++ b/modules/nixos/sourceos-shell/default.nix
@@ -35,6 +35,20 @@ in
       default = 7073;
       description = "Local port for the sourceos-shell derive/docd service.";
     };
+
+    searchProvider = {
+      mode = lib.mkOption {
+        type = lib.types.enum [ "linux-native" "launcher-bridge" "shell-native" ];
+        default = "launcher-bridge";
+        description = "Search routing mode during shell rollout.";
+      };
+
+      linuxFileProvider = lib.mkOption {
+        type = lib.types.enum [ "tracker3" "fd" "locate" ];
+        default = "tracker3";
+        description = "Linux-native file search provider used when scope=files.";
+      };
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -45,7 +59,20 @@ in
       routerPort=${toString cfg.routerPort}
       pdfSecurePort=${toString cfg.pdfSecurePort}
       docdPort=${toString cfg.docdPort}
+      searchProvider.mode=${cfg.searchProvider.mode}
+      searchProvider.linuxFileProvider=${cfg.searchProvider.linuxFileProvider}
     '';
+
+    environment.etc."sourceos-shell/search-provider.json".text = builtins.toJSON {
+      mode = cfg.searchProvider.mode;
+      linuxFileProvider = cfg.searchProvider.linuxFileProvider;
+      invariant = "no_redundant_file_search";
+      scopes = {
+        apps = "launcher";
+        files = "linux-native-only";
+        web = "browser-agent";
+      };
+    };
 
     systemd.services.sourceos-shell = {
       description = "SourceOS shell runtime scaffold";

--- a/modules/nixos/sourceos-shell/default.nix
+++ b/modules/nixos/sourceos-shell/default.nix
@@ -44,8 +44,8 @@ in
       };
 
       linuxFileProvider = lib.mkOption {
-        type = lib.types.enum [ "tracker3" "fd" "locate" ];
-        default = "tracker3";
+        type = lib.types.enum [ "lampstand" "fd" "locate" ];
+        default = "lampstand";
         description = "Linux-native file search provider used when scope=files.";
       };
     };
@@ -72,6 +72,10 @@ in
         files = "linux-native-only";
         web = "browser-agent";
       };
+      notes = [
+        "Lampstand is the Linux-native file authority for scope=files."
+        "The launcher remains an action bus and must not perform a second file-search pass."
+      ];
     };
 
     systemd.services.sourceos-shell = {

--- a/tests/sourceos-shell-module-contract.nix
+++ b/tests/sourceos-shell-module-contract.nix
@@ -5,6 +5,7 @@ pkgs.runCommand "sourceos-shell-module-contract" {
   test -f ${../modules/nixos/sourceos-shell/default.nix}
   test -f ${../profiles/linux-dev/sourceos-shell.nix}
   test -f ${../linux/desktop/sourceos-shell.desktop}
+  test -f ${../linux/desktop/sourceos-search-provider.conf}
   test -f ${../linux/systemd/sourceos-shell.service}
   test -f ${../linux/systemd/sourceos-router.service}
   test -f ${../linux/systemd/sourceos-pdf-secure.service}
@@ -12,6 +13,8 @@ pkgs.runCommand "sourceos-shell-module-contract" {
   grep -q '../../modules/nixos/sourceos-shell/default.nix' ${../profiles/linux-dev/sourceos-shell.nix}
   grep -q 'sourceos.shell' ${../modules/nixos/sourceos-shell/default.nix}
   grep -q 'sourceos-docd' ${../modules/nixos/sourceos-shell/default.nix}
+  grep -q 'searchProvider' ${../modules/nixos/sourceos-shell/default.nix}
+  grep -q 'no_redundant_file_search' ${../linux/desktop/sourceos-search-provider.conf}
   mkdir -p $out
   echo validated > $out/result.txt
 ''


### PR DESCRIPTION
## Summary

Stacked on top of the current `sourceos-shell` Linux realization chain, this PR adds the first explicit search-provider scaffold for the temporary launcher bridge and records the `no_redundant_file_search` invariant in both config and tests.

## Added files

- `linux/desktop/sourceos-search-provider.conf`

## Updated files

- `modules/nixos/sourceos-shell/default.nix`
- `tests/sourceos-shell-module-contract.nix`
- `docs/sourceos-shell-launcher-bridge.md`

## What it does

- adds `sourceos.shell.searchProvider.mode`
- adds `sourceos.shell.searchProvider.linuxFileProvider`
- realizes `/etc/sourceos-shell/search-provider.json`
- records the rollout invariant:
  - `apps` -> launcher
  - `files` -> Linux-native-only
  - `web` -> browser-agent
- extends the shell module contract test to assert the search-provider scaffold exists and records `no_redundant_file_search`

## Why

The previous Linux PRs established service scaffolds and a launcher bridge note, but they did not yet materialize the search-provider policy as a concrete Linux-facing artifact. This PR closes that gap while the runtime repo still does not exist.

## Stack relationship

This PR is stacked on top of:
- `source-os#26`
- `source-os#70`
- `source-os#71`

## Follow-on

- replace scaffold config with real runtime-owned config once `SourceOS-Linux/sourceos-shell` exists
- bind the launcher bridge implementation to this config surface
- upgrade tests from scaffold assertions to actual routing/service checks
