### PR TITLE
runtime: add sourceos-shell systemd target and service graph scaffold

### DIFF
--- a/docs/sourceos-shell-service-graph.md
+++ b/docs/sourceos-shell-service-graph.md
@@ -1,0 +1,18 @@
+# sourceos-shell service graph note
+
+The Linux realization layer currently models the `sourceos-shell` runtime as a four-service graph:
+
+- `sourceos-shell`
+- `sourceos-router`
+- `sourceos-pdf-secure`
+- `sourceos-docd`
+
+These services are grouped by the `sourceos-shell.target` scaffold.
+
+## Intent
+
+This target is a Linux realization placeholder that captures the expected runtime grouping before the actual product/runtime repo exists.
+
+## Follow-on
+
+Once `SourceOS-Linux/sourceos-shell` exists, the placeholder ExecStart values should be replaced with real package/service paths and the current scaffold checks should be upgraded into service-graph checks.

--- a/linux/systemd/sourceos-shell.target
+++ b/linux/systemd/sourceos-shell.target
@@ -1,0 +1,4 @@
+[Unit]
+Description=SourceOS shell service graph
+Wants=sourceos-shell.service sourceos-router.service sourceos-pdf-secure.service sourceos-docd.service
+After=network-online.target

--- a/modules/nixos/sourceos-shell/default.nix
+++ b/modules/nixos/sourceos-shell/default.nix
@@ -74,9 +74,17 @@ in
       };
     };
 
+    systemd.targets.sourceos-shell = {
+      description = "SourceOS shell service graph";
+      wants = [ "sourceos-shell.service" "sourceos-router.service" "sourceos-pdf-secure.service" "sourceos-docd.service" ];
+      after = [ "network-online.target" ];
+      wantedBy = [ "multi-user.target" ];
+    };
+
     systemd.services.sourceos-shell = {
       description = "SourceOS shell runtime scaffold";
       wantedBy = [ "multi-user.target" ];
+      partOf = [ "sourceos-shell.target" ];
       serviceConfig = {
         Type = "simple";
         ExecStart = "${pkgs.coreutils}/bin/echo sourceos-shell runtime placeholder root=${cfg.packageRoot} port=${toString cfg.shellPort}";
@@ -86,6 +94,7 @@ in
     systemd.services.sourceos-router = {
       description = "SourceOS shell router scaffold";
       wantedBy = [ "multi-user.target" ];
+      partOf = [ "sourceos-shell.target" ];
       serviceConfig = {
         Type = "simple";
         ExecStart = "${pkgs.coreutils}/bin/echo sourceos-router placeholder port=${toString cfg.routerPort}";
@@ -95,6 +104,7 @@ in
     systemd.services.sourceos-pdf-secure = {
       description = "SourceOS shell pdf-secure scaffold";
       wantedBy = [ "multi-user.target" ];
+      partOf = [ "sourceos-shell.target" ];
       serviceConfig = {
         Type = "simple";
         ExecStart = "${pkgs.coreutils}/bin/echo sourceos-pdf-secure placeholder port=${toString cfg.pdfSecurePort}";
@@ -104,6 +114,7 @@ in
     systemd.services.sourceos-docd = {
       description = "SourceOS shell docd scaffold";
       wantedBy = [ "multi-user.target" ];
+      partOf = [ "sourceos-shell.target" ];
       serviceConfig = {
         Type = "simple";
         ExecStart = "${pkgs.coreutils}/bin/echo sourceos-docd placeholder port=${toString cfg.docdPort}";

--- a/tests/sourceos-shell-module-contract.nix
+++ b/tests/sourceos-shell-module-contract.nix
@@ -10,11 +10,15 @@ pkgs.runCommand "sourceos-shell-module-contract" {
   test -f ${../linux/systemd/sourceos-router.service}
   test -f ${../linux/systemd/sourceos-pdf-secure.service}
   test -f ${../linux/systemd/sourceos-docd.service}
+  test -f ${../linux/systemd/sourceos-shell.target}
   grep -q '../../modules/nixos/sourceos-shell/default.nix' ${../profiles/linux-dev/sourceos-shell.nix}
   grep -q 'sourceos.shell' ${../modules/nixos/sourceos-shell/default.nix}
   grep -q 'sourceos-docd' ${../modules/nixos/sourceos-shell/default.nix}
   grep -q 'searchProvider' ${../modules/nixos/sourceos-shell/default.nix}
+  grep -q 'systemd.targets.sourceos-shell' ${../modules/nixos/sourceos-shell/default.nix}
+  grep -q 'partOf = \[ "sourceos-shell.target" \]' ${../modules/nixos/sourceos-shell/default.nix}
   grep -q 'no_redundant_file_search' ${../linux/desktop/sourceos-search-provider.conf}
+  grep -q 'sourceos-shell.service sourceos-router.service sourceos-pdf-secure.service sourceos-docd.service' ${../linux/systemd/sourceos-shell.target}
   mkdir -p $out
   echo validated > $out/result.txt
 ''


### PR DESCRIPTION
## Summary

Stacked on top of the current `sourceos-shell` Linux realization chain, this PR adds a first-class `sourceos-shell.target` scaffold and extends the contract-style test to assert the service graph grouping is present.

## Added files

- `linux/systemd/sourceos-shell.target`
- `docs/sourceos-shell-service-graph.md`

## Updated files

- `modules/nixos/sourceos-shell/default.nix`
- `tests/sourceos-shell-module-contract.nix`

## What it does

- adds `systemd.targets.sourceos-shell` to the Nix module scaffold
- groups the current four service scaffolds under that target:
  - `sourceos-shell`
  - `sourceos-router`
  - `sourceos-pdf-secure`
  - `sourceos-docd`
- marks each scaffold service as `partOf = [ "sourceos-shell.target" ]`
- extends the contract test to verify the target scaffold and the grouping assumptions

## Why

The previous Linux PRs added service scaffolds individually, but the runtime surface was still missing an explicit service-graph grouping. This PR turns the current set of shell-related services into a coherent Linux target scaffold while the real product/runtime repo is still pending.

## Stack relationship

This PR is stacked on top of:
- `source-os#26`
- `source-os#70`
- `source-os#71`
- `source-os#72`

## Follow-on

- replace placeholder ExecStart values with real runtime/package paths once `SourceOS-Linux/sourceos-shell` exists
- upgrade scaffold assertions into actual service-graph checks
- tie the launcher/search-provider config to the eventual runtime-owned implementation
