### PR TITLE
workstation-v0: add mac-like GNOME defaults pack

### DIFF
--- a/docs/workstation/README.md
+++ b/docs/workstation/README.md
@@ -36,6 +36,7 @@ Workflow file:
 - Primary keyboard remap lane: `input-remapper` on Fedora/GNOME.
 - Compatibility remap lanes: `xremap` and `kinto` (explicit compatibility path, not default).
 - Touchpad gesture lane: `fusuma`.
+- Mac-like GNOME behavior pack: left-side window controls, hot corners off, 12h clock, Files on `Super+E`, Terminal on `Super+Return`, dock favorites seeded.
 - Local status/doctor surfaces that can be opened from the launcher (`sourceos status --open`, `sourceos doctor --open`).
 
 ## Apply

--- a/profiles/linux-dev/workstation-v0/doctor.sh
+++ b/profiles/linux-dev/workstation-v0/doctor.sh
@@ -218,6 +218,48 @@ check_fusuma_lane(){
   fi
 }
 
+check_gsettings_equals(){
+  local schema=$1
+  local key=$2
+  local expected=$3
+  local name=$4
+  local got
+  got=$(gsettings get "$schema" "$key" 2>/dev/null || true)
+  if [[ "$got" == "$expected" ]]; then
+    info "ok: $name"
+    record_result ok "$name" "$expected"
+  else
+    warn "$name mismatch: got=${got:-unset} expected=$expected"
+    record_result warn "$name" "expected=$expected got=${got:-unset}"
+  fi
+}
+
+check_gsettings_contains(){
+  local schema=$1
+  local key=$2
+  local needle=$3
+  local name=$4
+  local got
+  got=$(gsettings get "$schema" "$key" 2>/dev/null || true)
+  if grep -Fq "$needle" <<<"$got"; then
+    info "ok: $name"
+    record_result ok "$name" "$needle"
+  else
+    warn "$name missing: $needle"
+    record_result warn "$name" "missing $needle"
+  fi
+}
+
+check_mac_defaults(){
+  check_gsettings_equals org.gnome.desktop.wm.preferences button-layout "'close,minimize,maximize:'" mac-button-layout
+  check_gsettings_equals org.gnome.desktop.interface enable-hot-corners "false" mac-hot-corners
+  check_gsettings_equals org.gnome.desktop.interface clock-format "'12h'" mac-clock-format
+  check_gsettings_contains org.gnome.settings-daemon.plugins.media-keys custom-keybindings "custom1" mac-custom-files-keybinding
+  check_gsettings_contains org.gnome.settings-daemon.plugins.media-keys custom-keybindings "custom2" mac-custom-terminal-keybinding
+  check_gsettings_equals org.gnome.settings-daemon.plugins.media-keys.custom-keybinding:/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom1/ binding "'<Super>e'" mac-files-binding
+  check_gsettings_equals org.gnome.settings-daemon.plugins.media-keys.custom-keybinding:/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom2/ binding "'<Super>Return'" mac-terminal-binding
+}
+
 main(){
   parse_args "$@"
 
@@ -292,6 +334,7 @@ main(){
         record_result info gnome-hotkey "$hk"
       fi
 
+      check_mac_defaults
     else
       warn "gnome: detected but gsettings missing"
       record_result warn gsettings "missing on GNOME host"

--- a/profiles/linux-dev/workstation-v0/gnome/mac-defaults.sh
+++ b/profiles/linux-dev/workstation-v0/gnome/mac-defaults.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Apply a mac-like GNOME defaults pack for workstation-v0.
+# Safe to run repeatedly.
+# Scope intentionally focuses on behavior and shell ergonomics, not deep theming.
+
+info(){ printf "INFO: %s\n" "$*" >&2; }
+warn(){ printf "WARN: %s\n" "$*" >&2; }
+
+have(){ command -v "$1" >/dev/null 2>&1; }
+
+is_gnome(){
+  [[ "${XDG_CURRENT_DESKTOP:-}" == *GNOME* ]] && return 0
+  [[ "${DESKTOP_SESSION:-}" == *gnome* ]] && return 0
+  return 1
+}
+
+set_key(){
+  local schema=$1; shift
+  local key=$1; shift
+  gsettings set "$schema" "$key" "$*" >/dev/null || true
+}
+
+set_custom_binding(){
+  local slot=$1
+  local name=$2
+  local command=$3
+  local binding=$4
+  local base="/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/"
+  local path="${base}${slot}/"
+
+  gsettings set org.gnome.settings-daemon.plugins.media-keys.custom-keybinding:${path} name "$name" || true
+  gsettings set org.gnome.settings-daemon.plugins.media-keys.custom-keybinding:${path} command "$command" || true
+  gsettings set org.gnome.settings-daemon.plugins.media-keys.custom-keybinding:${path} binding "$binding" || true
+}
+
+main(){
+  if ! have gsettings; then
+    warn "gsettings not found; skipping mac defaults pack"
+    exit 0
+  fi
+
+  if ! is_gnome; then
+    warn "GNOME not detected; skipping mac defaults pack"
+    exit 0
+  fi
+
+  info "Applying mac-like GNOME defaults pack"
+
+  # Interface / shell behavior
+  set_key org.gnome.desktop.interface enable-hot-corners false
+  set_key org.gnome.desktop.interface show-battery-percentage true
+  set_key org.gnome.desktop.interface clock-show-weekday true
+  set_key org.gnome.desktop.interface clock-show-date true
+  set_key org.gnome.desktop.interface clock-format '12h'
+  set_key org.gnome.desktop.interface locate-pointer true
+  set_key org.gnome.desktop.sound event-sounds false
+  set_key org.gnome.desktop.sound input-feedback-sounds false
+
+  # Files / Finder-like behavior
+  set_key org.gnome.nautilus.preferences click-policy 'double'
+  set_key org.gnome.nautilus.preferences show-delete-permanently true
+
+  # Favorites / dock seed (best-effort)
+  set_key org.gnome.shell favorite-apps "['org.gnome.Nautilus.desktop', 'org.gnome.Terminal.desktop', 'firefox.desktop', 'org.gnome.Settings.desktop']"
+
+  # Preserve palette hotkey in custom0, then add Finder/Terminal-like bindings.
+  local base="/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/"
+  local custom0="${base}custom0/"
+  local custom1="${base}custom1/"
+  local custom2="${base}custom2/"
+  gsettings set org.gnome.settings-daemon.plugins.media-keys custom-keybindings "['${custom0}', '${custom1}', '${custom2}']" || true
+
+  set_custom_binding custom1 "SourceOS Files" "nautilus --new-window" "<Super>e"
+  set_custom_binding custom2 "SourceOS Terminal" "gnome-terminal" "<Super>Return"
+
+  info "Mac-like GNOME defaults pack applied"
+}
+
+main "$@"

--- a/profiles/linux-dev/workstation-v0/install.sh
+++ b/profiles/linux-dev/workstation-v0/install.sh
@@ -172,6 +172,16 @@ apply_palette_hotkey(){
   fi
 }
 
+apply_mac_defaults(){
+  local script="$PROFILE_DIR/gnome/mac-defaults.sh"
+  if [[ -x "$script" ]]; then
+    info "Applying mac-like GNOME defaults pack (best-effort)"
+    "$script" || warn "mac defaults pack failed (non-fatal)"
+  else
+    warn "mac defaults script not found: $script"
+  fi
+}
+
 main(){
   [[ -f "$MANIFEST" ]] || { err "manifest missing: $MANIFEST"; exit 2; }
   install_system
@@ -186,6 +196,7 @@ main(){
   apply_fusuma_config
   apply_launcher_install
   apply_palette_hotkey
+  apply_mac_defaults
   info "installed workstation-v0 (linux-dev)"
   info "next: ./doctor.sh"
 }


### PR DESCRIPTION
Adds the first real mac-like GNOME behavior pack for workstation-v0.

Changes:
- `profiles/linux-dev/workstation-v0/gnome/mac-defaults.sh`
  - apply mac-like GNOME defaults:
    - left-side window controls
    - hot corners off
    - 12h clock + weekday/date
    - locate pointer enabled
    - event sounds off
    - Nautilus double-click policy + permanent delete option
    - seed dock favorites
    - `Super+E` for Files
    - `Super+Return` for Terminal
- `profiles/linux-dev/workstation-v0/install.sh`
  - apply the mac-defaults pack after launcher/hotkey setup
- `profiles/linux-dev/workstation-v0/doctor.sh`
  - validate key mac-default settings via gsettings
- `docs/workstation/README.md`
  - reflect the mac-like GNOME behavior pack in workstation goals

Why:
- The workstation profile had good operator/reporting substrate and initial input/gesture lanes, but the actual desktop behavior pack was still thin.
- This PR closes the first visible desktop UX gap.
