### PR TITLE
workstation-v0: add doctor artifact symmetry to sourceos CLI

### DIFF
--- a/.github/workflows/workstation-scripts.yml
+++ b/.github/workflows/workstation-scripts.yml
@@ -193,6 +193,53 @@ jobs:
           printf '# fish\n' > "$tmp"
           SOURCEOS_PROFILE_DIR=profiles/linux-dev/workstation-v0 SOURCEOS_FISH_CONFIG="$tmp" bash "$f" fix fish dry-run >/dev/null
 
+      - name: Smoke: doctor JSON contract parses
+        run: |
+          set -euo pipefail
+          export PATH="$(pwd)/profiles/linux-dev/workstation-v0/bin:$PATH"
+          d='profiles/linux-dev/workstation-v0/doctor.sh'
+          set +e
+          out=$(SOURCEOS_PROFILE_DIR=profiles/linux-dev/workstation-v0 bash "$d" --json)
+          rc=$?
+          set -e
+          if [ "$rc" -ne 0 ] && [ "$rc" -ne 2 ]; then
+            echo "Unexpected exit code: $rc" >&2
+            exit 1
+          fi
+          python3 -c 'import json,sys; j=json.loads(sys.stdin.read()); assert j["kind"]=="sourceos.doctor"; assert j["profile"]=="linux-dev/workstation-v0"; assert "summary" in j; assert isinstance(j["results"], list); print("ok")' <<<"$out"
+
+      - name: Smoke: sourceos doctor JSON contract parses
+        run: |
+          set -euo pipefail
+          f='profiles/linux-dev/workstation-v0/bin/sourceos'
+          export PATH="$(pwd)/profiles/linux-dev/workstation-v0/bin:$PATH"
+          set +e
+          out=$(SOURCEOS_PROFILE_DIR=profiles/linux-dev/workstation-v0 bash "$f" doctor --json)
+          rc=$?
+          set -e
+          if [ "$rc" -ne 0 ] && [ "$rc" -ne 2 ]; then
+            echo "Unexpected exit code: $rc" >&2
+            exit 1
+          fi
+          python3 -c 'import json,sys; j=json.loads(sys.stdin.read()); assert j["kind"]=="sourceos.doctor"; assert j["profile"]=="linux-dev/workstation-v0"; print("ok")' <<<"$out"
+
+      - name: Smoke: sourceos doctor report file writes
+        run: |
+          set -euo pipefail
+          f='profiles/linux-dev/workstation-v0/bin/sourceos'
+          export PATH="$(pwd)/profiles/linux-dev/workstation-v0/bin:$PATH"
+          out_json=$(mktemp)
+          set +e
+          SOURCEOS_PROFILE_DIR=profiles/linux-dev/workstation-v0 bash "$f" doctor --write "$out_json" >/dev/null
+          rc=$?
+          set -e
+          if [ "$rc" -ne 0 ] && [ "$rc" -ne 2 ]; then
+            echo "Unexpected exit code: $rc" >&2
+            exit 1
+          fi
+          test -s "$out_json"
+          python3 -c 'import json,sys; j=json.load(open(sys.argv[1])); assert j["kind"]=="sourceos.doctor"; print("ok")' "$out_json"
+
       - name: Smoke: sourceos status JSON parses
         run: |
           set -euo pipefail

--- a/profiles/linux-dev/workstation-v0/bin/sourceos
+++ b/profiles/linux-dev/workstation-v0/bin/sourceos
@@ -47,7 +47,7 @@ Usage:
   sourceos fix all [apply|dry-run|revert] [--json] [--open|--write <path>]
   sourceos fix shell [apply|dry-run|revert] [--json] [--open|--write <path>]
   sourceos fix fish [apply|dry-run|revert] [--json] [--open|--write <path>]
-  sourceos doctor [--open]
+  sourceos doctor [--json|--open|--write <path>]
   sourceos status [--json|--open|--write <path>]
   sourceos profile apply
   sourceos profile path
@@ -63,6 +63,10 @@ FIX_MODE="apply"
 FIX_JSON=0
 FIX_OPEN=0
 FIX_WRITE_PATH=""
+
+DOCTOR_JSON=0
+DOCTOR_OPEN=0
+DOCTOR_WRITE_PATH=""
 
 parse_fix_args(){
   FIX_MODE="apply"
@@ -101,6 +105,38 @@ parse_fix_args(){
   done
 }
 
+parse_doctor_args(){
+  DOCTOR_JSON=0
+  DOCTOR_OPEN=0
+  DOCTOR_WRITE_PATH=""
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --json)
+        DOCTOR_JSON=1
+        shift
+        ;;
+      --open)
+        DOCTOR_OPEN=1
+        shift
+        ;;
+      --write)
+        shift
+        if [[ $# -eq 0 ]]; then
+          err "--write requires a path"
+          exit 2
+        fi
+        DOCTOR_WRITE_PATH="$1"
+        shift
+        ;;
+      *)
+        err "unknown doctor argument: $1 (use [--json|--open|--write <path>])"
+        exit 2
+        ;;
+    esac
+  done
+}
+
 fix_report_path(){
   local target=$1
   local mode=$2
@@ -108,6 +144,14 @@ fix_report_path(){
   d="$(cache_dir)"
   mkdir -p "$d"
   printf '%s/fix-%s-%s.json\n' "$d" "$target" "$mode"
+}
+
+doctor_report_path(){
+  local kind=$1
+  local d
+  d="$(cache_dir)"
+  mkdir -p "$d"
+  printf '%s/doctor.%s\n' "$d" "$kind"
 }
 
 write_text(){
@@ -123,24 +167,45 @@ write_text(){
 run_doctor(){
   local doc="$PROFILE_DIR/doctor.sh"
   [[ -x "$doc" ]] || { err "doctor not found: $doc"; exit 2; }
-  exec "$doc"
-}
 
-run_doctor_open(){
-  local doc="$PROFILE_DIR/doctor.sh"
-  [[ -x "$doc" ]] || { err "doctor not found: $doc"; exit 2; }
+  if [[ "$DOCTOR_JSON" == "0" && "$DOCTOR_OPEN" == "0" && -z "$DOCTOR_WRITE_PATH" ]]; then
+    exec "$doc"
+  fi
 
-  local d
-  d="$(cache_dir)"
-  mkdir -p "$d"
-  local out="$d/doctor.txt"
+  if [[ "$DOCTOR_JSON" == "0" && "$DOCTOR_OPEN" == "1" && -z "$DOCTOR_WRITE_PATH" ]]; then
+    local out_txt
+    out_txt="$(doctor_report_path txt)"
+    set +e
+    "$doc" >"$out_txt" 2>&1
+    local rc=$?
+    set -e
+    open_file "$out_txt"
+    exit "$rc"
+  fi
 
+  local out_json rc final_path=""
   set +e
-  "$doc" >"$out" 2>&1
-  local rc=$?
+  out_json="$($doc --json)"
+  rc=$?
   set -e
 
-  open_file "$out"
+  if [[ -n "$DOCTOR_WRITE_PATH" ]]; then
+    final_path="$DOCTOR_WRITE_PATH"
+  elif [[ "$DOCTOR_OPEN" == "1" ]]; then
+    final_path="$(doctor_report_path json)"
+  fi
+
+  if [[ -n "$final_path" ]]; then
+    write_text "$final_path" "$out_json"
+    if [[ "$DOCTOR_OPEN" == "1" ]]; then
+      open_file "$final_path"
+    fi
+  fi
+
+  if [[ "$DOCTOR_JSON" == "1" ]]; then
+    printf '%s\n' "$out_json"
+  fi
+
   exit "$rc"
 }
 
@@ -371,6 +436,7 @@ status_write(){
 palette_menu(){
   # Print menu entries as: label<TAB>command
   cat <<'EOF'
+Palette: Audit doctor (open JSON report)	sourceos doctor --json --open
 Palette: Audit fix all (open report)	sourceos fix all dry-run --open
 Palette: Fix all configs (dry-run)	sourceos fix all dry-run
 Palette: Fix all configs (apply)	sourceos fix all apply
@@ -384,7 +450,7 @@ Palette: Fix fish config (dry-run)	sourceos fix fish dry-run
 Palette: Fix fish config (apply)	sourceos fix fish apply
 Palette: Revert fish config patch	sourceos fix fish revert
 Status (open report)	sourceos status --open
-Doctor (open report)	sourceos doctor --open
+Doctor (open text report)	sourceos doctor --open
 Apply profile	sourceos profile apply
 Open sesh	sesh
 Open tmux	tmux
@@ -464,11 +530,8 @@ main(){
 
     doctor)
       shift || true
-      case "${1:-}" in
-        --open) run_doctor_open ;;
-        "") run_doctor ;;
-        *) run_doctor ;;
-      esac
+      parse_doctor_args "$@"
+      run_doctor
       ;;
 
     status)


### PR DESCRIPTION
Adds top-level doctor artifact symmetry so the workstation health path matches the existing fix/report surface.

Changes:
- `profiles/linux-dev/workstation-v0/bin/sourceos`
  - extend `sourceos doctor` to support:
    - `--json`
    - `--write <path>`
    - `--open`
  - `--open` now supports both text and JSON report flows
  - palette adds an audit-style doctor JSON report action
- `.github/workflows/workstation-scripts.yml`
  - add smoke for `doctor.sh --json`
  - add smoke for `sourceos doctor --json`
  - add smoke for `sourceos doctor --write <path>` artifact emission and JSON parse

Why:
- Fix surfaces already support machine-readable artifacts and operator-friendly report workflows.
- Doctor should have the same first-class artifact ergonomics.
- This closes the local evidence symmetry for workstation health.
