### PR TITLE
test(runtime): add sourceos-shell service graph contract check

### DIFF
--- a/docs/sourceos-shell-service-graph.md
+++ b/docs/sourceos-shell-service-graph.md
@@ -13,6 +13,18 @@ These services are grouped by the `sourceos-shell.target` scaffold.
 
 This target is a Linux realization placeholder that captures the expected runtime grouping before the actual product/runtime repo exists.
 
+## Validation scaffold
+
+The current Linux realization adds a dedicated contract-style check at:
+
+- `tests/sourceos-shell-service-graph-contract.nix`
+
+This check verifies that:
+
+- `sourceos-shell.target` exists
+- the four runtime scaffold services are grouped beneath that target
+- the Nix module expresses the target and `partOf` relationships consistently
+
 ## Follow-on
 
-Once `SourceOS-Linux/sourceos-shell` exists, the placeholder ExecStart values should be replaced with real package/service paths and the current scaffold checks should be upgraded into service-graph checks.
+Once `SourceOS-Linux/sourceos-shell` exists, the placeholder ExecStart values should be replaced with real package/service paths and the current scaffold checks should be upgraded into actual runtime/service-graph checks.

--- a/flake.nix
+++ b/flake.nix
@@ -67,6 +67,7 @@
             '';
 
           sourceos-shell-module-contract = import ./tests/sourceos-shell-module-contract.nix { inherit pkgs; };
+          sourceos-shell-service-graph-contract = import ./tests/sourceos-shell-service-graph-contract.nix { inherit pkgs; };
         });
 
       sourceos = {

--- a/tests/sourceos-shell-service-graph-contract.nix
+++ b/tests/sourceos-shell-service-graph-contract.nix
@@ -1,0 +1,12 @@
+{ pkgs ? import <nixpkgs> {} }:
+pkgs.runCommand "sourceos-shell-service-graph-contract" {
+  nativeBuildInputs = [ pkgs.gnugrep ];
+} ''
+  test -f ${../linux/systemd/sourceos-shell.target}
+  grep -q 'sourceos-shell.service sourceos-router.service sourceos-pdf-secure.service sourceos-docd.service' ${../linux/systemd/sourceos-shell.target}
+  grep -q 'systemd.targets.sourceos-shell' ${../modules/nixos/sourceos-shell/default.nix}
+  grep -q 'partOf = \[ "sourceos-shell.target" \]' ${../modules/nixos/sourceos-shell/default.nix}
+  grep -q 'sourceos-shell.target' ${../docs/sourceos-shell-service-graph.md}
+  mkdir -p $out
+  echo validated > $out/result.txt
+''


### PR DESCRIPTION
## Summary

Stacked on top of the current `sourceos-shell` Linux realization chain, this PR adds a dedicated service-graph contract check and wires it into the flake checks so the shell target grouping is validated explicitly.

## Added files

- `tests/sourceos-shell-service-graph-contract.nix`

## Updated files

- `flake.nix`
- `docs/sourceos-shell-service-graph.md`

## What it does

- adds a new contract-style check for the shell service graph
- verifies that `sourceos-shell.target` exists
- verifies that the current four runtime scaffolds are grouped beneath the target:
  - `sourceos-shell`
  - `sourceos-router`
  - `sourceos-pdf-secure`
  - `sourceos-docd`
- wires the check into `flake.nix`
- updates the service-graph documentation to mention the check explicitly

## Why

The previous PR introduced the target scaffold and the `partOf` relationships. This follow-on PR makes that grouping enforceable in the repo's check surface rather than leaving it only as implementation convention.

## Stack relationship

This PR is stacked on top of:
- `source-os#26`
- `source-os#70`
- `source-os#71`
- `source-os#72`
- `source-os#73`

## Follow-on

- replace placeholder runtime paths once `SourceOS-Linux/sourceos-shell` exists
- turn scaffold checks into executable service/runtime checks when the real runtime repo lands
