### PR TITLE
runtime: add sourceos-shell keyboard equivalence scaffold

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -68,6 +68,7 @@
 
           sourceos-shell-module-contract = import ./tests/sourceos-shell-module-contract.nix { inherit pkgs; };
           sourceos-shell-service-graph-contract = import ./tests/sourceos-shell-service-graph-contract.nix { inherit pkgs; };
+          sourceos-shell-keyboard-equivalence-contract = import ./tests/sourceos-shell-keyboard-equivalence-contract.nix { inherit pkgs; };
         });
 
       sourceos = {

--- a/linux/desktop/sourceos-keyboard-equivalence.conf
+++ b/linux/desktop/sourceos-keyboard-equivalence.conf
@@ -1,0 +1,23 @@
+# SourceOS shell keyboard-equivalence scaffold
+# Transitional Mac-on-Linux shortcut model.
+
+mode=kinto-bridge
+platform-model=mac-like
+terminal-model=mac-terminal-like
+
+# GUI lanes
+copy=Cmd-C
+paste=Cmd-V
+tab-next=Cmd-Shift-]
+tab-prev=Cmd-Shift-[
+window-switch=Cmd-Tab
+launcher=Cmd-Space
+
+# Terminal lanes
+interrupt=Ctrl-C
+terminal-copy=Cmd-C
+terminal-paste=Cmd-V
+word-left=Alt-Left
+word-right=Alt-Right
+
+invariant=gui_terminal_split_explicit

--- a/tests/sourceos-shell-keyboard-equivalence-contract.nix
+++ b/tests/sourceos-shell-keyboard-equivalence-contract.nix
@@ -1,0 +1,14 @@
+{ pkgs ? import <nixpkgs> {} }:
+pkgs.runCommand "sourceos-shell-keyboard-equivalence-contract" {
+  nativeBuildInputs = [ pkgs.gnugrep ];
+} ''
+  test -f ${../linux/desktop/sourceos-keyboard-equivalence.conf}
+  grep -q 'mode=kinto-bridge' ${../linux/desktop/sourceos-keyboard-equivalence.conf}
+  grep -q 'platform-model=mac-like' ${../linux/desktop/sourceos-keyboard-equivalence.conf}
+  grep -q 'terminal-model=mac-terminal-like' ${../linux/desktop/sourceos-keyboard-equivalence.conf}
+  grep -q '# GUI lanes' ${../linux/desktop/sourceos-keyboard-equivalence.conf}
+  grep -q '# Terminal lanes' ${../linux/desktop/sourceos-keyboard-equivalence.conf}
+  grep -q 'invariant=gui_terminal_split_explicit' ${../linux/desktop/sourceos-keyboard-equivalence.conf}
+  mkdir -p $out
+  echo validated > $out/result.txt
+''


### PR DESCRIPTION
## Summary

Stacked on top of the current `sourceos-shell` Linux realization chain, this PR adds the first explicit keyboard-equivalence scaffold for the Mac-on-Linux rollout.

## Added files

- `linux/desktop/sourceos-keyboard-equivalence.conf`

## What it does

Adds a transitional keyboard-equivalence configuration that:

- records `mode=kinto-bridge`
- records `platform-model=mac-like`
- records `terminal-model=mac-terminal-like`
- distinguishes GUI and terminal lanes explicitly
- records the invariant `gui_terminal_split_explicit`

## Why

The Mac-on-Linux umbrella has a dedicated keyboard/shortcut lane, but the Linux realization repo did not yet carry a concrete artifact representing that shortcut model. This PR adds the first Linux-facing scaffold for that lane.

## Stack relationship

This PR is stacked on top of:
- `source-os#26`
- `source-os#70`
- `source-os#71`
- `source-os#72`
- `source-os#73`
- `source-os#76`

## Follow-on

- add module options and realized `/etc/sourceos-shell/keyboard-equivalence.json`
- add contract-style checks for the keyboard scaffold
- align the shortcut matrix with the keyboard/shortcut equivalence issue lane tracked in `#78`
- replace transitional bridge assumptions once the actual `SourceOS-Linux/sourceos-shell` runtime repo exists
