### PR TITLE
test(runtime): add sourceos-shell keyboard equivalence contract check

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -68,6 +68,7 @@
 
           sourceos-shell-module-contract = import ./tests/sourceos-shell-module-contract.nix { inherit pkgs; };
           sourceos-shell-service-graph-contract = import ./tests/sourceos-shell-service-graph-contract.nix { inherit pkgs; };
+          sourceos-shell-keyboard-equivalence-contract = import ./tests/sourceos-shell-keyboard-equivalence-contract.nix { inherit pkgs; };
         });
 
       sourceos = {

--- a/tests/sourceos-shell-keyboard-equivalence-contract.nix
+++ b/tests/sourceos-shell-keyboard-equivalence-contract.nix
@@ -1,0 +1,14 @@
+{ pkgs ? import <nixpkgs> {} }:
+pkgs.runCommand "sourceos-shell-keyboard-equivalence-contract" {
+  nativeBuildInputs = [ pkgs.gnugrep ];
+} ''
+  test -f ${../linux/desktop/sourceos-keyboard-equivalence.conf}
+  grep -q 'mode=kinto-bridge' ${../linux/desktop/sourceos-keyboard-equivalence.conf}
+  grep -q 'platform-model=mac-like' ${../linux/desktop/sourceos-keyboard-equivalence.conf}
+  grep -q 'terminal-model=mac-terminal-like' ${../linux/desktop/sourceos-keyboard-equivalence.conf}
+  grep -q '# GUI lanes' ${../linux/desktop/sourceos-keyboard-equivalence.conf}
+  grep -q '# Terminal lanes' ${../linux/desktop/sourceos-keyboard-equivalence.conf}
+  grep -q 'invariant=gui_terminal_split_explicit' ${../linux/desktop/sourceos-keyboard-equivalence.conf}
+  mkdir -p $out
+  echo validated > $out/result.txt
+''


### PR DESCRIPTION
## Summary

Stacked on top of the current `sourceos-shell` Linux realization chain, this PR adds a dedicated keyboard-equivalence contract check and wires it into the flake checks.

## Added files

- `tests/sourceos-shell-keyboard-equivalence-contract.nix`

## Updated files

- `flake.nix`

## What it does

- adds a contract-style check for the keyboard scaffold introduced in `#82`
- verifies that `linux/desktop/sourceos-keyboard-equivalence.conf` exists
- verifies that the scaffold explicitly records:
  - `mode=kinto-bridge`
  - `platform-model=mac-like`
  - `terminal-model=mac-terminal-like`
  - separate GUI and terminal lanes
  - `invariant=gui_terminal_split_explicit`
- wires the check into `flake.nix`

## Why

The keyboard lane now has its first Linux-facing artifact, but it was not yet enforced by the repository check surface. This PR makes that scaffold reviewable and checkable without stepping on the broader ongoing workstreams.

## Stack relationship

This PR is stacked on top of:
- `source-os#26`
- `source-os#70`
- `source-os#71`
- `source-os#72`
- `source-os#73`
- `source-os#76`
- `source-os#82`

## Follow-on

- add keyboard module options and a realized `/etc/sourceos-shell/keyboard-equivalence.json`
- align the runtime-owned behavior with the keyboard lane in `#78`
- migrate from bridge assumptions once the actual `SourceOS-Linux/sourceos-shell` repo exists
