### PR TITLE
runtime: add sourceos-shell keyboard module options and realized config scaffold

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -69,6 +69,7 @@
           sourceos-shell-module-contract = import ./tests/sourceos-shell-module-contract.nix { inherit pkgs; };
           sourceos-shell-service-graph-contract = import ./tests/sourceos-shell-service-graph-contract.nix { inherit pkgs; };
           sourceos-shell-keyboard-equivalence-contract = import ./tests/sourceos-shell-keyboard-equivalence-contract.nix { inherit pkgs; };
+          sourceos-shell-keyboard-module-contract = import ./tests/sourceos-shell-keyboard-module-contract.nix { inherit pkgs; };
         });
 
       sourceos = {

--- a/modules/nixos/sourceos-shell/default.nix
+++ b/modules/nixos/sourceos-shell/default.nix
@@ -36,6 +36,26 @@ in
       description = "Local port for the sourceos-shell derive/docd service.";
     };
 
+    keyboard = {
+      mode = lib.mkOption {
+        type = lib.types.enum [ "linux-default" "bridge" "shell-native" ];
+        default = "bridge";
+        description = "Keyboard equivalence mode during rollout.";
+      };
+
+      platformModel = lib.mkOption {
+        type = lib.types.enum [ "mac-like" "linux-default" ];
+        default = "mac-like";
+        description = "High-level shortcut model expected by the shell on Linux hosts.";
+      };
+
+      terminalModel = lib.mkOption {
+        type = lib.types.enum [ "terminal-like" "linux-default" ];
+        default = "terminal-like";
+        description = "Terminal-specific shortcut model used during rollout.";
+      };
+    };
+
     searchProvider = {
       mode = lib.mkOption {
         type = lib.types.enum [ "linux-native" "launcher-bridge" "shell-native" ];
@@ -59,9 +79,19 @@ in
       routerPort=${toString cfg.routerPort}
       pdfSecurePort=${toString cfg.pdfSecurePort}
       docdPort=${toString cfg.docdPort}
+      keyboard.mode=${cfg.keyboard.mode}
+      keyboard.platformModel=${cfg.keyboard.platformModel}
+      keyboard.terminalModel=${cfg.keyboard.terminalModel}
       searchProvider.mode=${cfg.searchProvider.mode}
       searchProvider.linuxFileProvider=${cfg.searchProvider.linuxFileProvider}
     '';
+
+    environment.etc."sourceos-shell/keyboard-equivalence.json".text = builtins.toJSON {
+      mode = cfg.keyboard.mode;
+      platformModel = cfg.keyboard.platformModel;
+      terminalModel = cfg.keyboard.terminalModel;
+      invariant = "gui_terminal_split_explicit";
+    };
 
     environment.etc."sourceos-shell/search-provider.json".text = builtins.toJSON {
       mode = cfg.searchProvider.mode;

--- a/tests/sourceos-shell-keyboard-module-contract.nix
+++ b/tests/sourceos-shell-keyboard-module-contract.nix
@@ -1,0 +1,13 @@
+{ pkgs ? import <nixpkgs> {} }:
+pkgs.runCommand "sourceos-shell-keyboard-module-contract" {
+  nativeBuildInputs = [ pkgs.gnugrep ];
+} ''
+  grep -q 'keyboard = {' ${../modules/nixos/sourceos-shell/default.nix}
+  grep -q 'mode = lib.mkOption' ${../modules/nixos/sourceos-shell/default.nix}
+  grep -q 'platformModel = lib.mkOption' ${../modules/nixos/sourceos-shell/default.nix}
+  grep -q 'terminalModel = lib.mkOption' ${../modules/nixos/sourceos-shell/default.nix}
+  grep -q 'keyboard-equivalence.json' ${../modules/nixos/sourceos-shell/default.nix}
+  grep -q 'gui_terminal_split_explicit' ${../modules/nixos/sourceos-shell/default.nix}
+  mkdir -p $out
+  echo validated > $out/result.txt
+''


### PR DESCRIPTION
## Summary

Stacked on top of the current keyboard-equivalence lane, this PR adds the first shell-module options for keyboard behavior and realizes a machine-facing keyboard config surface under `/etc/sourceos-shell/`.

## Added files

- `tests/sourceos-shell-keyboard-module-contract.nix`

## Updated files

- `modules/nixos/sourceos-shell/default.nix`
- `flake.nix`

## What it does

- adds `sourceos.shell.keyboard.mode`
- adds `sourceos.shell.keyboard.platformModel`
- adds `sourceos.shell.keyboard.terminalModel`
- realizes `/etc/sourceos-shell/keyboard-equivalence.json`
- records the keyboard invariant `gui_terminal_split_explicit`
- adds a dedicated contract-style check for the keyboard module surface
- wires that check into `flake.nix`

## Why

The previous keyboard PR introduced the first Linux-facing artifact for the keyboard lane. This follow-on patch connects that lane to the shell Nix module so the rollout has a machine-level configuration surface instead of only a desktop-side config file.

## Stack relationship

This PR is stacked on top of:
- `source-os#26`
- `source-os#70`
- `source-os#71`
- `source-os#72`
- `source-os#73`
- `source-os#76`
- `source-os#82`
- `source-os#83`

## Follow-on

- align the realized config with the keyboard/shortcut equivalence lane tracked in `#78`
- connect launcher/search behavior with the keyboard mode where necessary
- replace transitional bridge assumptions once the actual `SourceOS-Linux/sourceos-shell` runtime repo exists
