### PR TITLE
sourceos-shell search provider uses command bus

### DIFF
--- a/docs/sourceos-shell-integration.md
+++ b/docs/sourceos-shell-integration.md
@@ -11,6 +11,7 @@ This repository, `source-os`, carries the Linux realization surfaces required to
 - Nix/NixOS modules
 - profile wiring
 - machine-level integration hooks
+- derive-service runtime integration such as `docd`
 
 ## What does not belong here
 

--- a/docs/sourceos-shell-launcher-bridge.md
+++ b/docs/sourceos-shell-launcher-bridge.md
@@ -14,6 +14,15 @@ Queries are routed by scope:
 
 For `files` queries, Albert must not perform a second file-search pass in parallel with the Linux-native provider.
 
+## Realization scaffolds
+
+The Linux realization currently carries placeholder search-provider material at:
+
+- `linux/desktop/sourceos-search-provider.conf`
+- `/etc/sourceos-shell/search-provider.json` (realized by the shell Nix module scaffold)
+
+These capture the intended rollout mode and the provider choice for the Linux-native file search lane.
+
 ## Lifecycle
 
 This bridge exists only until the shell's own command/search surface fully absorbs the routing behavior.

--- a/docs/sourceos-shell-launcher-bridge.md
+++ b/docs/sourceos-shell-launcher-bridge.md
@@ -1,6 +1,6 @@
-# sourceos-shell launcher bridge note
+# sourceos-shell command bus note
 
-During the early shell rollout, launcher integration is tracked as temporary bridge work.
+During the early shell rollout, launcher/search integration is tracked as temporary command-bus work.
 
 ## Routing rule
 
@@ -12,7 +12,9 @@ Queries are routed by scope:
 
 ## Required invariant
 
-For `files` queries, Albert must not perform a second file-search pass in parallel with the Linux-native provider.
+For `files` queries, the command bus must not perform a second file-search pass in parallel with the Linux-native provider.
+
+Lampstand is the intended Linux-native file authority for this lane.
 
 ## Realization scaffolds
 
@@ -21,8 +23,8 @@ The Linux realization currently carries placeholder search-provider material at:
 - `linux/desktop/sourceos-search-provider.conf`
 - `/etc/sourceos-shell/search-provider.json` (realized by the shell Nix module scaffold)
 
-These capture the intended rollout mode and the provider choice for the Linux-native file search lane.
+These capture the intended rollout mode, routing invariant, and the provider choice for the Linux-native file search lane.
 
 ## Lifecycle
 
-This bridge exists only until the shell's own command/search surface fully absorbs the routing behavior.
+This command-bus/search-provider surface exists only until the shell's own command/search runtime fully absorbs the routing behavior.

--- a/docs/sourceos-shell-launcher-bridge.md
+++ b/docs/sourceos-shell-launcher-bridge.md
@@ -1,0 +1,19 @@
+# sourceos-shell launcher bridge note
+
+During the early shell rollout, launcher integration is tracked as temporary bridge work.
+
+## Routing rule
+
+Queries are routed by scope:
+
+- `apps` -> launcher or desktop-entry provider
+- `files` -> Linux-native file search only
+- `web` -> browser or web agent
+
+## Required invariant
+
+For `files` queries, Albert must not perform a second file-search pass in parallel with the Linux-native provider.
+
+## Lifecycle
+
+This bridge exists only until the shell's own command/search surface fully absorbs the routing behavior.

--- a/docs/sourceos-shell-service-graph.md
+++ b/docs/sourceos-shell-service-graph.md
@@ -1,0 +1,18 @@
+# sourceos-shell service graph note
+
+The Linux realization layer currently models the `sourceos-shell` runtime as a four-service graph:
+
+- `sourceos-shell`
+- `sourceos-router`
+- `sourceos-pdf-secure`
+- `sourceos-docd`
+
+These services are grouped by the `sourceos-shell.target` scaffold.
+
+## Intent
+
+This target is a Linux realization placeholder that captures the expected runtime grouping before the actual product/runtime repo exists.
+
+## Follow-on
+
+Once `SourceOS-Linux/sourceos-shell` exists, the placeholder ExecStart values should be replaced with real package/service paths and the current scaffold checks should be upgraded into service-graph checks.

--- a/flake.nix
+++ b/flake.nix
@@ -65,6 +65,8 @@
             else pkgs.runCommand "stable-x86_64-smoke-skip" {} ''
               mkdir -p $out
             '';
+
+          sourceos-shell-module-contract = import ./tests/sourceos-shell-module-contract.nix { inherit pkgs; };
         });
 
       sourceos = {

--- a/linux/desktop/sourceos-search-provider.conf
+++ b/linux/desktop/sourceos-search-provider.conf
@@ -1,0 +1,11 @@
+# SourceOS shell search-provider scaffold
+# This file records the intended launcher/search routing policy during early shell rollout.
+
+mode=launcher-bridge
+linux-file-provider=tracker3
+invariant=no_redundant_file_search
+
+# scopes
+apps=launcher
+files=linux-native-only
+web=browser-agent

--- a/linux/desktop/sourceos-search-provider.conf
+++ b/linux/desktop/sourceos-search-provider.conf
@@ -1,7 +1,7 @@
 # SourceOS shell search-provider scaffold
-# This file records the intended launcher/search routing policy during early shell rollout.
+# This file records the intended command-bus/search routing policy during early shell rollout.
 
-mode=launcher-bridge
+mode=command-bus
 linux-file-provider=lampstand
 invariant=no_redundant_file_search
 
@@ -12,4 +12,4 @@ web=browser-agent
 
 # notes
 # - Lampstand is the Linux-native file authority for scope=files.
-# - The launcher remains an action bus and must not perform a second file-search pass.
+# - The command bus remains a frontend and must not perform a second file-search pass.

--- a/linux/desktop/sourceos-search-provider.conf
+++ b/linux/desktop/sourceos-search-provider.conf
@@ -2,10 +2,14 @@
 # This file records the intended launcher/search routing policy during early shell rollout.
 
 mode=launcher-bridge
-linux-file-provider=tracker3
+linux-file-provider=lampstand
 invariant=no_redundant_file_search
 
 # scopes
 apps=launcher
 files=linux-native-only
 web=browser-agent
+
+# notes
+# - Lampstand is the Linux-native file authority for scope=files.
+# - The launcher remains an action bus and must not perform a second file-search pass.

--- a/linux/systemd/sourceos-docd.service
+++ b/linux/systemd/sourceos-docd.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=SourceOS docd derive service
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/opt/sourceos-shell/bin/sourceos-docd
+Restart=on-failure
+RestartSec=2s
+
+[Install]
+WantedBy=multi-user.target

--- a/linux/systemd/sourceos-shell.target
+++ b/linux/systemd/sourceos-shell.target
@@ -1,0 +1,4 @@
+[Unit]
+Description=SourceOS shell service graph
+Wants=sourceos-shell.service sourceos-router.service sourceos-pdf-secure.service sourceos-docd.service
+After=network-online.target

--- a/modules/nixos/sourceos-shell/default.nix
+++ b/modules/nixos/sourceos-shell/default.nix
@@ -38,8 +38,8 @@ in
 
     searchProvider = {
       mode = lib.mkOption {
-        type = lib.types.enum [ "linux-native" "launcher-bridge" "shell-native" ];
-        default = "launcher-bridge";
+        type = lib.types.enum [ "linux-native" "command-bus" "shell-native" ];
+        default = "command-bus";
         description = "Search routing mode during shell rollout.";
       };
 
@@ -74,7 +74,7 @@ in
       };
       notes = [
         "Lampstand is the Linux-native file authority for scope=files."
-        "The launcher remains an action bus and must not perform a second file-search pass."
+        "The command bus remains a frontend and must not perform a second file-search pass."
       ];
     };
 

--- a/modules/nixos/sourceos-shell/default.nix
+++ b/modules/nixos/sourceos-shell/default.nix
@@ -74,9 +74,17 @@ in
       };
     };
 
+    systemd.targets.sourceos-shell = {
+      description = "SourceOS shell service graph";
+      wants = [ "sourceos-shell.service" "sourceos-router.service" "sourceos-pdf-secure.service" "sourceos-docd.service" ];
+      after = [ "network-online.target" ];
+      wantedBy = [ "multi-user.target" ];
+    };
+
     systemd.services.sourceos-shell = {
       description = "SourceOS shell runtime scaffold";
       wantedBy = [ "multi-user.target" ];
+      partOf = [ "sourceos-shell.target" ];
       serviceConfig = {
         Type = "simple";
         ExecStart = "${pkgs.coreutils}/bin/echo sourceos-shell runtime placeholder root=${cfg.packageRoot} port=${toString cfg.shellPort}";
@@ -86,6 +94,7 @@ in
     systemd.services.sourceos-router = {
       description = "SourceOS shell router scaffold";
       wantedBy = [ "multi-user.target" ];
+      partOf = [ "sourceos-shell.target" ];
       serviceConfig = {
         Type = "simple";
         ExecStart = "${pkgs.coreutils}/bin/echo sourceos-router placeholder port=${toString cfg.routerPort}";
@@ -95,6 +104,7 @@ in
     systemd.services.sourceos-pdf-secure = {
       description = "SourceOS shell pdf-secure scaffold";
       wantedBy = [ "multi-user.target" ];
+      partOf = [ "sourceos-shell.target" ];
       serviceConfig = {
         Type = "simple";
         ExecStart = "${pkgs.coreutils}/bin/echo sourceos-pdf-secure placeholder port=${toString cfg.pdfSecurePort}";
@@ -104,6 +114,7 @@ in
     systemd.services.sourceos-docd = {
       description = "SourceOS shell docd scaffold";
       wantedBy = [ "multi-user.target" ];
+      partOf = [ "sourceos-shell.target" ];
       serviceConfig = {
         Type = "simple";
         ExecStart = "${pkgs.coreutils}/bin/echo sourceos-docd placeholder port=${toString cfg.docdPort}";

--- a/modules/nixos/sourceos-shell/default.nix
+++ b/modules/nixos/sourceos-shell/default.nix
@@ -35,6 +35,20 @@ in
       default = 7073;
       description = "Local port for the sourceos-shell derive/docd service.";
     };
+
+    searchProvider = {
+      mode = lib.mkOption {
+        type = lib.types.enum [ "linux-native" "launcher-bridge" "shell-native" ];
+        default = "launcher-bridge";
+        description = "Search routing mode during shell rollout.";
+      };
+
+      linuxFileProvider = lib.mkOption {
+        type = lib.types.enum [ "tracker3" "fd" "locate" ];
+        default = "tracker3";
+        description = "Linux-native file search provider used when scope=files.";
+      };
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -45,7 +59,20 @@ in
       routerPort=${toString cfg.routerPort}
       pdfSecurePort=${toString cfg.pdfSecurePort}
       docdPort=${toString cfg.docdPort}
+      searchProvider.mode=${cfg.searchProvider.mode}
+      searchProvider.linuxFileProvider=${cfg.searchProvider.linuxFileProvider}
     '';
+
+    environment.etc."sourceos-shell/search-provider.json".text = builtins.toJSON {
+      mode = cfg.searchProvider.mode;
+      linuxFileProvider = cfg.searchProvider.linuxFileProvider;
+      invariant = "no_redundant_file_search";
+      scopes = {
+        apps = "launcher";
+        files = "linux-native-only";
+        web = "browser-agent";
+      };
+    };
 
     systemd.services.sourceos-shell = {
       description = "SourceOS shell runtime scaffold";

--- a/modules/nixos/sourceos-shell/default.nix
+++ b/modules/nixos/sourceos-shell/default.nix
@@ -73,5 +73,14 @@ in
         ExecStart = "${pkgs.coreutils}/bin/echo sourceos-pdf-secure placeholder port=${toString cfg.pdfSecurePort}";
       };
     };
+
+    systemd.services.sourceos-docd = {
+      description = "SourceOS shell docd scaffold";
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        Type = "simple";
+        ExecStart = "${pkgs.coreutils}/bin/echo sourceos-docd placeholder port=${toString cfg.docdPort}";
+      };
+    };
   };
 }

--- a/modules/nixos/sourceos-shell/default.nix
+++ b/modules/nixos/sourceos-shell/default.nix
@@ -44,8 +44,8 @@ in
       };
 
       linuxFileProvider = lib.mkOption {
-        type = lib.types.enum [ "tracker3" "fd" "locate" ];
-        default = "tracker3";
+        type = lib.types.enum [ "lampstand" "fd" "locate" ];
+        default = "lampstand";
         description = "Linux-native file search provider used when scope=files.";
       };
     };
@@ -72,6 +72,10 @@ in
         files = "linux-native-only";
         web = "browser-agent";
       };
+      notes = [
+        "Lampstand is the Linux-native file authority for scope=files."
+        "The launcher remains an action bus and must not perform a second file-search pass."
+      ];
     };
 
     systemd.services.sourceos-shell = {

--- a/profiles/linux-dev/default.nix
+++ b/profiles/linux-dev/default.nix
@@ -2,6 +2,7 @@
 {
   imports = [
     ../../modules/build/default.nix
+    ../../profiles/linux-dev/sourceos-shell.nix
   ];
 
   sourceos.build = {

--- a/tests/sourceos-shell-module-contract.nix
+++ b/tests/sourceos-shell-module-contract.nix
@@ -1,0 +1,15 @@
+{ pkgs ? import <nixpkgs> {} }:
+pkgs.runCommand "sourceos-shell-module-contract" {
+  nativeBuildInputs = [ pkgs.gnugrep ];
+} ''
+  test -f ${../modules/nixos/sourceos-shell/default.nix}
+  test -f ${../profiles/linux-dev/sourceos-shell.nix}
+  test -f ${../linux/desktop/sourceos-shell.desktop}
+  test -f ${../linux/systemd/sourceos-shell.service}
+  test -f ${../linux/systemd/sourceos-router.service}
+  test -f ${../linux/systemd/sourceos-pdf-secure.service}
+  grep -q '../../modules/nixos/sourceos-shell/default.nix' ${../profiles/linux-dev/sourceos-shell.nix}
+  grep -q 'sourceos.shell' ${../modules/nixos/sourceos-shell/default.nix}
+  mkdir -p $out
+  echo validated > $out/result.txt
+''

--- a/tests/sourceos-shell-module-contract.nix
+++ b/tests/sourceos-shell-module-contract.nix
@@ -5,6 +5,7 @@ pkgs.runCommand "sourceos-shell-module-contract" {
   test -f ${../modules/nixos/sourceos-shell/default.nix}
   test -f ${../profiles/linux-dev/sourceos-shell.nix}
   test -f ${../linux/desktop/sourceos-shell.desktop}
+  test -f ${../linux/desktop/sourceos-search-provider.conf}
   test -f ${../linux/systemd/sourceos-shell.service}
   test -f ${../linux/systemd/sourceos-router.service}
   test -f ${../linux/systemd/sourceos-pdf-secure.service}
@@ -12,6 +13,8 @@ pkgs.runCommand "sourceos-shell-module-contract" {
   grep -q '../../modules/nixos/sourceos-shell/default.nix' ${../profiles/linux-dev/sourceos-shell.nix}
   grep -q 'sourceos.shell' ${../modules/nixos/sourceos-shell/default.nix}
   grep -q 'sourceos-docd' ${../modules/nixos/sourceos-shell/default.nix}
+  grep -q 'searchProvider' ${../modules/nixos/sourceos-shell/default.nix}
+  grep -q 'no_redundant_file_search' ${../linux/desktop/sourceos-search-provider.conf}
   mkdir -p $out
   echo validated > $out/result.txt
 ''

--- a/tests/sourceos-shell-module-contract.nix
+++ b/tests/sourceos-shell-module-contract.nix
@@ -8,8 +8,10 @@ pkgs.runCommand "sourceos-shell-module-contract" {
   test -f ${../linux/systemd/sourceos-shell.service}
   test -f ${../linux/systemd/sourceos-router.service}
   test -f ${../linux/systemd/sourceos-pdf-secure.service}
+  test -f ${../linux/systemd/sourceos-docd.service}
   grep -q '../../modules/nixos/sourceos-shell/default.nix' ${../profiles/linux-dev/sourceos-shell.nix}
   grep -q 'sourceos.shell' ${../modules/nixos/sourceos-shell/default.nix}
+  grep -q 'sourceos-docd' ${../modules/nixos/sourceos-shell/default.nix}
   mkdir -p $out
   echo validated > $out/result.txt
 ''

--- a/tests/sourceos-shell-module-contract.nix
+++ b/tests/sourceos-shell-module-contract.nix
@@ -10,11 +10,15 @@ pkgs.runCommand "sourceos-shell-module-contract" {
   test -f ${../linux/systemd/sourceos-router.service}
   test -f ${../linux/systemd/sourceos-pdf-secure.service}
   test -f ${../linux/systemd/sourceos-docd.service}
+  test -f ${../linux/systemd/sourceos-shell.target}
   grep -q '../../modules/nixos/sourceos-shell/default.nix' ${../profiles/linux-dev/sourceos-shell.nix}
   grep -q 'sourceos.shell' ${../modules/nixos/sourceos-shell/default.nix}
   grep -q 'sourceos-docd' ${../modules/nixos/sourceos-shell/default.nix}
   grep -q 'searchProvider' ${../modules/nixos/sourceos-shell/default.nix}
+  grep -q 'systemd.targets.sourceos-shell' ${../modules/nixos/sourceos-shell/default.nix}
+  grep -q 'partOf = \[ "sourceos-shell.target" \]' ${../modules/nixos/sourceos-shell/default.nix}
   grep -q 'no_redundant_file_search' ${../linux/desktop/sourceos-search-provider.conf}
+  grep -q 'sourceos-shell.service sourceos-router.service sourceos-pdf-secure.service sourceos-docd.service' ${../linux/systemd/sourceos-shell.target}
   mkdir -p $out
   echo validated > $out/result.txt
 ''


### PR DESCRIPTION
Superseded by merged PR #88, which replayed the sourceos-shell command-bus/search-provider work from current main without stale branch history.