### PR TITLE
sourceos-shell command-bus search provider scaffold

### DIFF
--- a/docs/sourceos-shell-command-bus.md
+++ b/docs/sourceos-shell-command-bus.md
@@ -1,0 +1,30 @@
+# sourceos-shell command bus note
+
+During the early shell rollout, launcher/search integration is tracked as temporary command-bus work.
+
+## Routing rule
+
+Queries are routed by scope:
+
+- `apps` -> launcher or desktop-entry provider
+- `files` -> Linux-native file search only
+- `web` -> browser or web agent
+
+## Required invariant
+
+For `files` queries, the command bus must not perform a second file-search pass in parallel with the Linux-native provider.
+
+Lampstand is the intended Linux-native file authority for this lane.
+
+## Realization scaffolds
+
+The Linux realization currently carries placeholder search-provider material at:
+
+- `linux/desktop/sourceos-search-provider.conf`
+- `/etc/sourceos-shell/search-provider.json` (realized by the shell Nix module scaffold)
+
+These capture the intended rollout mode, routing invariant, and the provider choice for the Linux-native file search lane.
+
+## Lifecycle
+
+This command-bus/search-provider surface exists only until the shell's own command/search runtime fully absorbs the routing behavior.

--- a/flake.nix
+++ b/flake.nix
@@ -146,6 +146,7 @@
           mesh-runtime-contract = import ./tests/mesh-runtime-contract.nix { inherit pkgs; };
           mesh-package-contract = import ./tests/mesh-package-contract.nix { inherit pkgs; };
           mesh-host-runtime-contract = import ./tests/mesh-host-runtime-contract.nix { inherit pkgs; };
+          sourceos-shell-module-contract = import ./tests/sourceos-shell-module-contract.nix { inherit pkgs; };
 
           meshd-package = self.packages.${system}.meshd;
           meshd-linkd-package = self.packages.${system}.meshd-linkd;

--- a/linux/desktop/sourceos-search-provider.conf
+++ b/linux/desktop/sourceos-search-provider.conf
@@ -1,0 +1,15 @@
+# SourceOS shell search-provider scaffold
+# This file records the intended command-bus/search routing policy during early shell rollout.
+
+mode=command-bus
+linux-file-provider=lampstand
+invariant=no_redundant_file_search
+
+# scopes
+apps=launcher
+files=linux-native-only
+web=browser-agent
+
+# notes
+# - Lampstand is the Linux-native file authority for scope=files.
+# - The command bus remains a frontend and must not perform a second file-search pass.

--- a/linux/systemd/sourceos-docd.service
+++ b/linux/systemd/sourceos-docd.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=SourceOS shell docd scaffold
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/env sh -c 'echo sourceos-docd placeholder'
+Restart=on-failure
+RestartSec=2
+
+[Install]
+WantedBy=multi-user.target

--- a/modules/nixos/sourceos-shell/default.nix
+++ b/modules/nixos/sourceos-shell/default.nix
@@ -35,6 +35,20 @@ in
       default = 7073;
       description = "Local port for the sourceos-shell derive/docd service.";
     };
+
+    searchProvider = {
+      mode = lib.mkOption {
+        type = lib.types.enum [ "linux-native" "command-bus" "shell-native" ];
+        default = "command-bus";
+        description = "Search routing mode during shell rollout.";
+      };
+
+      linuxFileProvider = lib.mkOption {
+        type = lib.types.enum [ "lampstand" "fd" "locate" ];
+        default = "lampstand";
+        description = "Linux-native file search provider used when scope=files.";
+      };
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -45,7 +59,24 @@ in
       routerPort=${toString cfg.routerPort}
       pdfSecurePort=${toString cfg.pdfSecurePort}
       docdPort=${toString cfg.docdPort}
+      searchProvider.mode=${cfg.searchProvider.mode}
+      searchProvider.linuxFileProvider=${cfg.searchProvider.linuxFileProvider}
     '';
+
+    environment.etc."sourceos-shell/search-provider.json".text = builtins.toJSON {
+      mode = cfg.searchProvider.mode;
+      linuxFileProvider = cfg.searchProvider.linuxFileProvider;
+      invariant = "no_redundant_file_search";
+      scopes = {
+        apps = "launcher";
+        files = "linux-native-only";
+        web = "browser-agent";
+      };
+      notes = [
+        "Lampstand is the Linux-native file authority for scope=files."
+        "The command bus remains a frontend and must not perform a second file-search pass."
+      ];
+    };
 
     systemd.services.sourceos-shell = {
       description = "SourceOS shell runtime scaffold";
@@ -71,6 +102,15 @@ in
       serviceConfig = {
         Type = "simple";
         ExecStart = "${pkgs.coreutils}/bin/echo sourceos-pdf-secure placeholder port=${toString cfg.pdfSecurePort}";
+      };
+    };
+
+    systemd.services.sourceos-docd = {
+      description = "SourceOS shell docd scaffold";
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        Type = "simple";
+        ExecStart = "${pkgs.coreutils}/bin/echo sourceos-docd placeholder port=${toString cfg.docdPort}";
       };
     };
   };

--- a/profiles/linux-dev/default.nix
+++ b/profiles/linux-dev/default.nix
@@ -3,6 +3,7 @@
   imports = [
     ../../modules/build/default.nix
     ../../modules/nixos/mesh/default.nix
+    ../../modules/nixos/sourceos-shell/default.nix
   ];
 
   sourceos.build = {

--- a/tests/sourceos-shell-module-contract.nix
+++ b/tests/sourceos-shell-module-contract.nix
@@ -1,0 +1,17 @@
+{ pkgs ? import <nixpkgs> {} }:
+pkgs.runCommand "sourceos-shell-module-contract" {
+  nativeBuildInputs = [ pkgs.gnugrep ];
+} ''
+  test -f ${../modules/nixos/sourceos-shell/default.nix}
+  test -f ${../profiles/linux-dev/default.nix}
+  test -f ${../linux/desktop/sourceos-search-provider.conf}
+  test -f ${../linux/systemd/sourceos-docd.service}
+  grep -q '../../modules/nixos/sourceos-shell/default.nix' ${../profiles/linux-dev/default.nix}
+  grep -q 'sourceos.shell' ${../modules/nixos/sourceos-shell/default.nix}
+  grep -q 'searchProvider' ${../modules/nixos/sourceos-shell/default.nix}
+  grep -q 'lampstand' ${../modules/nixos/sourceos-shell/default.nix}
+  grep -q 'command-bus' ${../linux/desktop/sourceos-search-provider.conf}
+  grep -q 'no_redundant_file_search' ${../linux/desktop/sourceos-search-provider.conf}
+  mkdir -p $out
+  echo validated > $out/result.txt
+''


### PR DESCRIPTION
Clean replacement branch for the sourceos-shell search-provider work.

This PR is based on current main and avoids the stale history in #87.

Adds:
- sourceos-shell command-bus/search-provider scaffold
- Lampstand as the Linux-native file provider for files scope
- no_redundant_file_search invariant
- flat config at linux/desktop/sourceos-search-provider.conf
- command-bus note
- docd placeholder service
- focused Nix contract check