### PR TITLE
build(source-os): add office desktop entry and install helper

### DIFF
--- a/build/office-suite/desktop/sourceos-office.desktop
+++ b/build/office-suite/desktop/sourceos-office.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Type=Application
+Name=SourceOS Office
+Comment=Open office documents using the SourceOS office shell
+Exec=sh -lc '"$HOME/.local/bin/sourceos-office-open" "%f"'
+Terminal=false
+MimeType=application/vnd.oasis.opendocument.text;application/vnd.oasis.opendocument.spreadsheet;application/vnd.oasis.opendocument.presentation;application/vnd.openxmlformats-officedocument.wordprocessingml.document;application/vnd.openxmlformats-officedocument.spreadsheetml.sheet;application/vnd.openxmlformats-officedocument.presentationml.presentation;application/msword;application/vnd.ms-excel;application/vnd.ms-powerpoint;
+Categories=Office;
+NoDisplay=false

--- a/build/office-suite/scripts/desktop_entry_install_smoke.sh
+++ b/build/office-suite/scripts/desktop_entry_install_smoke.sh
@@ -36,4 +36,9 @@ grep -q "application/vnd.oasis.opendocument.text=libreoffice-writer.desktop" "$M
   exit 1
 }
 
+grep -q "sourceos-office-open" "$DESKTOP_FILE" || {
+  echo "desktop entry install smoke failed: desktop entry does not reference launcher helper" >&2
+  exit 1
+}
+
 echo "desktop entry install smoke passed"

--- a/build/office-suite/scripts/desktop_entry_install_smoke.sh
+++ b/build/office-suite/scripts/desktop_entry_install_smoke.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+export XDG_DATA_HOME="$TMPDIR/share"
+export HOME="$TMPDIR/home"
+mkdir -p "$HOME"
+
+"$ROOT/build/office-suite/scripts/install_office_desktop_entry.sh" >/dev/null
+
+DESKTOP_FILE="$XDG_DATA_HOME/applications/sourceos-office.desktop"
+BIN_FILE="$HOME/.local/bin/sourceos-office-open"
+
+[[ -f "$DESKTOP_FILE" ]] || {
+  echo "desktop entry install smoke failed: missing desktop file" >&2
+  exit 1
+}
+
+[[ -x "$BIN_FILE" ]] || {
+  echo "desktop entry install smoke failed: missing launcher helper" >&2
+  exit 1
+}
+
+echo "desktop entry install smoke passed"

--- a/build/office-suite/scripts/desktop_entry_install_smoke.sh
+++ b/build/office-suite/scripts/desktop_entry_install_smoke.sh
@@ -6,6 +6,7 @@ TMPDIR="$(mktemp -d)"
 trap 'rm -rf "$TMPDIR"' EXIT
 
 export XDG_DATA_HOME="$TMPDIR/share"
+export XDG_CONFIG_HOME="$TMPDIR/config"
 export HOME="$TMPDIR/home"
 mkdir -p "$HOME"
 
@@ -13,6 +14,7 @@ mkdir -p "$HOME"
 
 DESKTOP_FILE="$XDG_DATA_HOME/applications/sourceos-office.desktop"
 BIN_FILE="$HOME/.local/bin/sourceos-office-open"
+MIME_FILE="$XDG_CONFIG_HOME/mimeapps.list"
 
 [[ -f "$DESKTOP_FILE" ]] || {
   echo "desktop entry install smoke failed: missing desktop file" >&2
@@ -21,6 +23,16 @@ BIN_FILE="$HOME/.local/bin/sourceos-office-open"
 
 [[ -x "$BIN_FILE" ]] || {
   echo "desktop entry install smoke failed: missing launcher helper" >&2
+  exit 1
+}
+
+[[ -f "$MIME_FILE" ]] || {
+  echo "desktop entry install smoke failed: missing MIME defaults" >&2
+  exit 1
+}
+
+grep -q "application/vnd.oasis.opendocument.text=libreoffice-writer.desktop" "$MIME_FILE" || {
+  echo "desktop entry install smoke failed: missing writer MIME association" >&2
   exit 1
 }
 

--- a/build/office-suite/scripts/install_office_desktop_entry.sh
+++ b/build/office-suite/scripts/install_office_desktop_entry.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+DESKTOP_SRC="$ROOT/build/office-suite/desktop/sourceos-office.desktop"
+BIN_SRC="$ROOT/build/office-suite/scripts/office_open.sh"
+APP_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/applications"
+BIN_DIR="$HOME/.local/bin"
+
+mkdir -p "$APP_DIR" "$BIN_DIR"
+cp "$DESKTOP_SRC" "$APP_DIR/sourceos-office.desktop"
+cp "$BIN_SRC" "$BIN_DIR/sourceos-office-open"
+chmod +x "$BIN_DIR/sourceos-office-open"
+
+echo "installed desktop entry to $APP_DIR/sourceos-office.desktop"
+echo "installed launcher helper to $BIN_DIR/sourceos-office-open"

--- a/build/office-suite/scripts/install_office_desktop_entry.sh
+++ b/build/office-suite/scripts/install_office_desktop_entry.sh
@@ -12,5 +12,8 @@ cp "$DESKTOP_SRC" "$APP_DIR/sourceos-office.desktop"
 cp "$BIN_SRC" "$BIN_DIR/sourceos-office-open"
 chmod +x "$BIN_DIR/sourceos-office-open"
 
+"$ROOT/build/office-suite/scripts/install_office_mime_defaults.sh" >/dev/null
+
 echo "installed desktop entry to $APP_DIR/sourceos-office.desktop"
 echo "installed launcher helper to $BIN_DIR/sourceos-office-open"
+echo "installed office MIME defaults"

--- a/build/office-suite/scripts/install_office_mime_defaults.sh
+++ b/build/office-suite/scripts/install_office_mime_defaults.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+MIME_SRC="$ROOT/configs/mime/sourceos-office-mimeapps.list"
+CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}"
+
+mkdir -p "$CONFIG_DIR"
+cp "$MIME_SRC" "$CONFIG_DIR/mimeapps.list"
+
+echo "installed MIME defaults to $CONFIG_DIR/mimeapps.list"

--- a/build/office-suite/scripts/mime_defaults_install_smoke.sh
+++ b/build/office-suite/scripts/mime_defaults_install_smoke.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+export XDG_CONFIG_HOME="$TMPDIR/config"
+
+"$ROOT/build/office-suite/scripts/install_office_mime_defaults.sh" >/dev/null
+
+TARGET="$XDG_CONFIG_HOME/mimeapps.list"
+[[ -f "$TARGET" ]] || {
+  echo "mime defaults install smoke failed: missing mimeapps.list" >&2
+  exit 1
+}
+
+grep -q "application/vnd.oasis.opendocument.text=libreoffice-writer.desktop" "$TARGET" || {
+  echo "mime defaults install smoke failed: missing writer association" >&2
+  exit 1
+}
+
+echo "mime defaults install smoke passed"

--- a/build/office-suite/scripts/verify_office_desktop_entry.sh
+++ b/build/office-suite/scripts/verify_office_desktop_entry.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+DESKTOP_FILE="$ROOT/build/office-suite/desktop/sourceos-office.desktop"
+INSTALLER="$ROOT/build/office-suite/scripts/install_office_desktop_entry.sh"
+MIME_INSTALLER="$ROOT/build/office-suite/scripts/install_office_mime_defaults.sh"
+
+[[ -f "$DESKTOP_FILE" ]] || {
+  echo "missing desktop entry source" >&2
+  exit 1
+}
+
+[[ -x "$INSTALLER" ]] || {
+  echo "missing desktop entry installer" >&2
+  exit 1
+}
+
+[[ -x "$MIME_INSTALLER" ]] || {
+  echo "missing MIME defaults installer" >&2
+  exit 1
+}
+
+grep -q "sourceos-office-open" "$DESKTOP_FILE" || {
+  echo "desktop entry does not reference launcher helper" >&2
+  exit 1
+}
+
+echo "office desktop entry verification passed"


### PR DESCRIPTION
## Summary

Add the first desktop-entry slice to `source-os`.

Files:
- `build/office-suite/desktop/sourceos-office.desktop`
- `build/office-suite/scripts/install_office_desktop_entry.sh`

## Cross-repo posture

- `prophet-workspace` = product semantics
- `prophet-platform` = cloud/runtime realization
- `source-os` = desktop and host realization
