### PR TITLE
test(runtime): add sourceos-shell search provider contract check

### DIFF
--- a/docs/sourceos-shell-launcher-bridge.md
+++ b/docs/sourceos-shell-launcher-bridge.md
@@ -23,6 +23,14 @@ The Linux realization currently carries placeholder search-provider material at:
 
 These capture the intended rollout mode and the provider choice for the Linux-native file search lane.
 
+## Validation scaffold
+
+The current Linux realization also adds a dedicated contract-style check at:
+
+- `tests/sourceos-shell-search-provider-contract.nix`
+
+This check verifies that the Linux-facing scaffold records the expected launcher/search policy and the `no_redundant_file_search` invariant.
+
 ## Lifecycle
 
 This bridge exists only until the shell's own command/search surface fully absorbs the routing behavior.

--- a/flake.nix
+++ b/flake.nix
@@ -67,6 +67,7 @@
             '';
 
           sourceos-shell-module-contract = import ./tests/sourceos-shell-module-contract.nix { inherit pkgs; };
+          sourceos-shell-search-provider-contract = import ./tests/sourceos-shell-search-provider-contract.nix { inherit pkgs; };
         });
 
       sourceos = {

--- a/tests/sourceos-shell-search-provider-contract.nix
+++ b/tests/sourceos-shell-search-provider-contract.nix
@@ -1,0 +1,16 @@
+{ pkgs ? import <nixpkgs> {} }:
+pkgs.runCommand "sourceos-shell-search-provider-contract" {
+  nativeBuildInputs = [ pkgs.gnugrep ];
+} ''
+  test -f ${../linux/desktop/sourceos-search-provider.conf}
+  grep -q 'mode=launcher-bridge' ${../linux/desktop/sourceos-search-provider.conf}
+  grep -q 'linux-file-provider=tracker3' ${../linux/desktop/sourceos-search-provider.conf}
+  grep -q 'invariant=no_redundant_file_search' ${../linux/desktop/sourceos-search-provider.conf}
+  grep -q 'apps=launcher' ${../linux/desktop/sourceos-search-provider.conf}
+  grep -q 'files=linux-native-only' ${../linux/desktop/sourceos-search-provider.conf}
+  grep -q 'web=browser-agent' ${../linux/desktop/sourceos-search-provider.conf}
+  grep -q 'search-provider.json' ${../modules/nixos/sourceos-shell/default.nix}
+  grep -q 'no_redundant_file_search' ${../modules/nixos/sourceos-shell/default.nix}
+  mkdir -p $out
+  echo validated > $out/result.txt
+''


### PR DESCRIPTION
## Summary

Stacked on top of the launcher/search lane scaffold, this PR adds a dedicated search-provider contract check and wires it into the flake checks.

## Added files

- `tests/sourceos-shell-search-provider-contract.nix`

## Updated files

- `flake.nix`
- `docs/sourceos-shell-launcher-bridge.md`

## What it does

- adds a contract-style check for the search-provider scaffold introduced in `#72`
- verifies that `linux/desktop/sourceos-search-provider.conf` exists
- verifies that the Linux-facing scaffold explicitly records:
  - `mode=launcher-bridge`
  - `linux-file-provider=tracker3`
  - `invariant=no_redundant_file_search`
  - scope routing for `apps`, `files`, and `web`
- verifies that the shell module scaffold still realizes the search-provider config
- wires the check into `flake.nix`
- updates the launcher/search doc to mention the check explicitly

## Why

The launcher/search lane already has a scaffold artifact and module-owned config surface, but it was not yet enforced by a dedicated repo check. This PR makes that lane explicitly checkable without stepping on the other active workstreams.

## Stack relationship

This PR is stacked on top of:
- `source-os#26`
- `source-os#70`
- `source-os#71`
- `source-os#72`

## Follow-on

- align provider-policy behavior with the launcher/search lane tracked in `#80`
- add logs/fixture-based routing validation once the runtime repo exists
- migrate from bridge assumptions once `SourceOS-Linux/sourceos-shell` exists
