### PR TITLE
workstation-v0 Lampstand docs and unit check

### DIFF
--- a/.github/workflows/workstation-lampstand.yml
+++ b/.github/workflows/workstation-lampstand.yml
@@ -3,6 +3,7 @@ name: workstation-lampstand
 on:
   pull_request:
     paths:
+      - 'profiles/linux-dev/workstation-v0/bin/check-lampstand-unit.sh'
       - 'profiles/linux-dev/workstation-v0/bin/install-lampstand.sh'
       - 'profiles/linux-dev/workstation-v0/bin/sourceos-search.sh'
       - 'profiles/linux-dev/workstation-v0/manifest.yaml'
@@ -11,6 +12,7 @@ on:
     branches:
       - main
     paths:
+      - 'profiles/linux-dev/workstation-v0/bin/check-lampstand-unit.sh'
       - 'profiles/linux-dev/workstation-v0/bin/install-lampstand.sh'
       - 'profiles/linux-dev/workstation-v0/bin/sourceos-search.sh'
       - 'profiles/linux-dev/workstation-v0/manifest.yaml'
@@ -26,6 +28,7 @@ jobs:
       - name: Syntax check installer and helper
         run: |
           set -euo pipefail
+          bash -n profiles/linux-dev/workstation-v0/bin/check-lampstand-unit.sh
           bash -n profiles/linux-dev/workstation-v0/bin/install-lampstand.sh
           bash -n profiles/linux-dev/workstation-v0/bin/sourceos-search.sh
 
@@ -59,6 +62,27 @@ jobs:
           svc="$tmp_home/.config/systemd/user/sourceos-lampstand.service"
           test -f "$svc"
           grep -F 'lampstandd --root %h --rpc unixjson' "$svc" >/dev/null
+
+      - name: Smoke: Lampstand unit check helper
+        run: |
+          set -euo pipefail
+          helper='profiles/linux-dev/workstation-v0/bin/check-lampstand-unit.sh'
+          stub_bin=$(mktemp -d)
+          tmp_home=$(mktemp -d)
+          mkdir -p "$tmp_home/.config/systemd/user"
+          touch "$tmp_home/.config/systemd/user/sourceos-lampstand.service"
+          cat > "$stub_bin/systemctl" <<'EOF'
+          #!/usr/bin/env bash
+          set -euo pipefail
+          test "${1:-}" = --user
+          test "${2:-}" = is-enabled || test "${2:-}" = is-active
+          exit 0
+          EOF
+          chmod +x "$stub_bin/systemctl"
+          out=$(HOME="$tmp_home" PATH="$stub_bin:$PATH" bash "$helper")
+          grep -F 'unit_file=present' <<<"$out" >/dev/null
+          grep -F 'enabled=yes' <<<"$out" >/dev/null
+          grep -F 'active=yes' <<<"$out" >/dev/null
 
       - name: Smoke: sourceos-search runtime commands with stub lampstand
         run: |

--- a/docs/workstation/README.md
+++ b/docs/workstation/README.md
@@ -24,7 +24,9 @@ Workstation scripts are guarded by the `workstation-scripts` GitHub Actions work
 The Lampstand provisioning/search lane is guarded by the `workstation-lampstand` workflow:
 - installer syntax checks
 - `sourceos-search.sh` syntax checks
-- stubbed `pipx` smoke proving the installer writes the user service
+- stubbed `pipx` smoke proving the installer writes the user unit
+- stubbed Lampstand smoke for query, health, stats, and index commands
+- stubbed unit smoke for status, restart, enable, and logs commands
 
 It triggers on PRs and main pushes touching:
 - `profiles/linux-dev/workstation-v0/**`
@@ -71,6 +73,22 @@ Or via the installed helper:
   sourceos doctor
   sourceos status --json
   sourceos search 'report OR invoice' --snippet
+
+## Lampstand runtime commands
+
+Search and runtime inspection are exposed through the same workstation helper so the launcher remains an action bus and Lampstand remains the file-search authority:
+
+  sourceos search 'report OR invoice' --snippet
+  sourceos search health --open
+  sourceos search stats --open
+  sourceos search index --root "$HOME"
+
+The helper also exposes local unit inspection and log retrieval:
+
+  sourceos search service status --open
+  sourceos search service restart
+  sourceos search service enable
+  sourceos search service logs --open
 
 ## Nix-first support
 

--- a/profiles/linux-dev/workstation-v0/bin/check-lampstand-unit.sh
+++ b/profiles/linux-dev/workstation-v0/bin/check-lampstand-unit.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Lightweight Lampstand user-unit check for workstation-v0.
+# Emits simple key=value lines so doctor/status paths can consume it without
+# depending on JSON tooling.
+
+unit_path(){
+  printf '%s/systemd/user/sourceos-lampstand.service\n' "${XDG_CONFIG_HOME:-$HOME/.config}"
+}
+
+have(){ command -v "$1" >/dev/null 2>&1; }
+
+svc='sourceos-lampstand.service'
+path="$(unit_path)"
+
+printf 'unit=%s\n' "$svc"
+printf 'path=%s\n' "$path"
+
+if [[ -f "$path" ]]; then
+  printf 'unit_file=present\n'
+else
+  printf 'unit_file=missing\n'
+fi
+
+if have systemctl; then
+  if systemctl --user is-enabled "$svc" >/dev/null 2>&1; then
+    printf 'enabled=yes\n'
+  else
+    printf 'enabled=no\n'
+  fi
+
+  if systemctl --user is-active "$svc" >/dev/null 2>&1; then
+    printf 'active=yes\n'
+  else
+    printf 'active=no\n'
+  fi
+else
+  printf 'enabled=unknown\n'
+  printf 'active=unknown\n'
+fi


### PR DESCRIPTION
Small hardening tranche after #95.

Adds:
- workstation docs for Lampstand runtime commands
- `check-lampstand-unit.sh` helper for the generated user unit
- CI smoke coverage for the unit-check helper

This keeps doctor/status integration as a later low-churn follow-up.