### PR TITLE
test(runtime): add sourceos-shell PDF stack contract check

### DIFF
--- a/docs/sourceos-shell-pdf-stack.md
+++ b/docs/sourceos-shell-pdf-stack.md
@@ -1,0 +1,26 @@
+# sourceos-shell PDF stack note
+
+This note tracks the Linux realization scaffold for the PDF lane during the `sourceos-shell` rollout.
+
+## Current Linux-facing surfaces
+
+The Linux realization currently carries service scaffolds for:
+
+- `sourceos-pdf-secure`
+- `sourceos-docd`
+
+These are represented both as systemd unit files under `linux/systemd/` and as service declarations in `modules/nixos/sourceos-shell/default.nix`.
+
+## Intent
+
+This is the Linux realization slice of the broader PDF lane tracked in `#93`.
+
+The future `SourceOS-Linux/sourceos-shell` runtime repo should own the actual PDF derivation, signing, validation, and viewing behavior. `source-os` should only keep the host/service realization and validation hooks.
+
+## Validation scaffold
+
+The current Linux realization adds a dedicated contract-style check at:
+
+- `tests/sourceos-shell-pdf-stack-contract.nix`
+
+This check verifies that the PDF-related runtime scaffolds and module hooks remain present and aligned.

--- a/flake.nix
+++ b/flake.nix
@@ -33,37 +33,16 @@
         let
           pkgs = nixpkgs.legacyPackages.${system};
 
-          # Workstation v0 CLI toolset (best-effort).
-          # We intentionally tolerate missing attrs to avoid breaking flake evaluation.
           workstationV0Names = [
-            # baseline
             "git" "jq" "nixpkgs-fmt"
-
-            # nav/shell
             "fzf" "atuin" "bat" "zoxide" "yazi" "eza" "gum" "direnv" "tldr" "fd" "ripgrep"
-
-            # find/replace
             "sd"
-
-            # git
             "lazygit" "gh" "diff-so-fancy" "tig" "svu"
-
-            # process/ops
             "tmux" "sesh" "mprocs" "procs" "lazydocker" "k9s" "btop"
-
-            # json
             "jnv" "gojq" "fx" "jless" "jqp"
-
-            # disk
             "dua" "dust" "kondo"
-
-            # docs/bench/watch
             "glow" "hyperfine" "entr" "curlie"
-
-            # file motion
             "rclone" "rsync" "minio-client"
-
-            # launcher (optional)
             "albert"
           ];
 
@@ -154,6 +133,7 @@
           mesh-package-contract = import ./tests/mesh-package-contract.nix { inherit pkgs; };
           mesh-host-runtime-contract = import ./tests/mesh-host-runtime-contract.nix { inherit pkgs; };
           sourceos-shell-module-contract = import ./tests/sourceos-shell-module-contract.nix { inherit pkgs; };
+          sourceos-shell-pdf-stack-contract = import ./tests/sourceos-shell-pdf-stack-contract.nix { inherit pkgs; };
 
           meshd-package = self.packages.${system}.meshd;
           meshd-linkd-package = self.packages.${system}.meshd-linkd;

--- a/tests/sourceos-shell-pdf-stack-contract.nix
+++ b/tests/sourceos-shell-pdf-stack-contract.nix
@@ -1,0 +1,15 @@
+{ pkgs ? import <nixpkgs> {} }:
+pkgs.runCommand "sourceos-shell-pdf-stack-contract" {
+  nativeBuildInputs = [ pkgs.gnugrep ];
+} ''
+  test -f ${../linux/systemd/sourceos-pdf-secure.service}
+  test -f ${../linux/systemd/sourceos-docd.service}
+  grep -q 'pdfSecurePort = lib.mkOption' ${../modules/nixos/sourceos-shell/default.nix}
+  grep -q 'docdPort = lib.mkOption' ${../modules/nixos/sourceos-shell/default.nix}
+  grep -q 'systemd.services.sourceos-pdf-secure' ${../modules/nixos/sourceos-shell/default.nix}
+  grep -q 'systemd.services.sourceos-docd' ${../modules/nixos/sourceos-shell/default.nix}
+  grep -q 'sourceos-pdf-secure' ${../linux/systemd/sourceos-pdf-secure.service}
+  grep -q 'sourceos-docd' ${../linux/systemd/sourceos-docd.service}
+  mkdir -p $out
+  echo validated > $out/result.txt
+''


### PR DESCRIPTION
## Summary

Add the first dedicated Linux-side contract check for the `sourceos-shell` PDF lane.

## Added files

- `tests/sourceos-shell-pdf-stack-contract.nix`
- `docs/sourceos-shell-pdf-stack.md`

## Updated files

- `flake.nix`

## What it does

- adds a contract-style check for the PDF lane
- verifies that the Linux realization still carries both runtime scaffolds:
  - `sourceos-pdf-secure`
  - `sourceos-docd`
- verifies that the shell module still exposes:
  - `pdfSecurePort`
  - `docdPort`
  - `systemd.services.sourceos-pdf-secure`
  - `systemd.services.sourceos-docd`
- wires the new check into `flake.nix`
- adds a short PDF stack note documenting the Linux-side boundary

## Why

The shell Linux realization already includes `pdf-secure` and `docd` scaffolds, and the contract repo already carries the typed PDF/document/publication family. What was missing was a dedicated Linux realization check and a lane-specific note tying those pieces together.

## Related tracker

- `source-os#93` — Track PDF derivation, signing, validation, and viewing lane for sourceos-shell rollout

## Follow-on

- add executable runtime checks once `SourceOS-Linux/sourceos-shell` exists
- replace placeholder service commands with real runtime/package paths
- bind the eventual viewer/runtime behavior to the typed artifact/report contracts already merged in `sourceos-spec`
