### PR TITLE
build(source-os): add SourceOS office shell installer wrapper

### DIFF
--- a/build/office-suite/scripts/install_sourceos_office_shell.sh
+++ b/build/office-suite/scripts/install_sourceos_office_shell.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+
+"$ROOT/build/office-suite/scripts/install_office_desktop_entry.sh"
+"$ROOT/build/office-suite/scripts/verify_office_desktop_entry.sh"
+
+if [[ -x "$ROOT/build/office-suite/scripts/verify_office_suite_profile.sh" ]]; then
+  "$ROOT/build/office-suite/scripts/verify_office_suite_profile.sh"
+fi
+
+echo "SourceOS office shell install completed"


### PR DESCRIPTION
## Summary

Add the next SourceOS office-shell integration slice on top of the merged host and desktop baselines.

Files:
- `build/office-suite/scripts/install_sourceos_office_shell.sh`

## Why

The host and desktop lines now provide:
- office profile defaults and smoke helpers
- desktop entry and MIME-defaults install path

This follow-on adds one single installer wrapper so the office shell has a clear operator entrypoint instead of separate install and verify commands.

## Cross-repo posture

- `prophet-workspace` = product semantics
- `prophet-platform` = cloud/runtime realization
- `source-os` = host/desktop office shell installation path
