### PR TITLE
runtime: add sourceos-shell PDF config surface and contract check

### DIFF
--- a/docs/sourceos-shell-pdf-stack.md
+++ b/docs/sourceos-shell-pdf-stack.md
@@ -11,6 +11,12 @@ The Linux realization currently carries service scaffolds for:
 
 These are represented both as systemd unit files under `linux/systemd/` and as service declarations in `modules/nixos/sourceos-shell/default.nix`.
 
+The Linux realization now also carries a machine-facing config surface at:
+
+- `/etc/sourceos-shell/pdf-stack.json`
+
+This config captures the relationship between the derive lane and the secure/sign-validate lane while the runtime repo is still absent.
+
 ## Intent
 
 This is the Linux realization slice of the broader PDF lane tracked in `#93`.
@@ -19,8 +25,9 @@ The future `SourceOS-Linux/sourceos-shell` runtime repo should own the actual PD
 
 ## Validation scaffold
 
-The current Linux realization adds a dedicated contract-style check at:
+The current Linux realization adds dedicated contract-style checks at:
 
 - `tests/sourceos-shell-pdf-stack-contract.nix`
+- `tests/sourceos-shell-pdf-config-contract.nix`
 
-This check verifies that the PDF-related runtime scaffolds and module hooks remain present and aligned.
+These checks verify that the PDF-related runtime scaffolds, module hooks, and realized config surface remain present and aligned.

--- a/flake.nix
+++ b/flake.nix
@@ -134,6 +134,7 @@
           mesh-host-runtime-contract = import ./tests/mesh-host-runtime-contract.nix { inherit pkgs; };
           sourceos-shell-module-contract = import ./tests/sourceos-shell-module-contract.nix { inherit pkgs; };
           sourceos-shell-pdf-stack-contract = import ./tests/sourceos-shell-pdf-stack-contract.nix { inherit pkgs; };
+          sourceos-shell-pdf-config-contract = import ./tests/sourceos-shell-pdf-config-contract.nix { inherit pkgs; };
 
           meshd-package = self.packages.${system}.meshd;
           meshd-linkd-package = self.packages.${system}.meshd-linkd;

--- a/modules/nixos/sourceos-shell/default.nix
+++ b/modules/nixos/sourceos-shell/default.nix
@@ -63,6 +63,21 @@ in
       searchProvider.linuxFileProvider=${cfg.searchProvider.linuxFileProvider}
     '';
 
+    environment.etc."sourceos-shell/pdf-stack.json".text = builtins.toJSON {
+      derive = {
+        service = "sourceos-docd";
+        port = cfg.docdPort;
+      };
+      secure = {
+        service = "sourceos-pdf-secure";
+        port = cfg.pdfSecurePort;
+      };
+      invariants = [
+        "artifact_manifest_required"
+        "signed_and_validation_reports_flow_from_runtime"
+      ];
+    };
+
     environment.etc."sourceos-shell/search-provider.json".text = builtins.toJSON {
       mode = cfg.searchProvider.mode;
       linuxFileProvider = cfg.searchProvider.linuxFileProvider;

--- a/tests/sourceos-shell-pdf-config-contract.nix
+++ b/tests/sourceos-shell-pdf-config-contract.nix
@@ -1,0 +1,12 @@
+{ pkgs ? import <nixpkgs> {} }:
+pkgs.runCommand "sourceos-shell-pdf-config-contract" {
+  nativeBuildInputs = [ pkgs.gnugrep ];
+} ''
+  grep -q 'pdf-stack.json' ${../modules/nixos/sourceos-shell/default.nix}
+  grep -q 'service = "sourceos-docd"' ${../modules/nixos/sourceos-shell/default.nix}
+  grep -q 'service = "sourceos-pdf-secure"' ${../modules/nixos/sourceos-shell/default.nix}
+  grep -q 'artifact_manifest_required' ${../modules/nixos/sourceos-shell/default.nix}
+  grep -q 'signed_and_validation_reports_flow_from_runtime' ${../modules/nixos/sourceos-shell/default.nix}
+  mkdir -p $out
+  echo validated > $out/result.txt
+''


### PR DESCRIPTION
## Summary

Stacked on top of the PDF lane scaffold, this PR adds the first machine-facing PDF config surface for the shell Linux realization and wires in a dedicated config contract check.

## Added files

- `tests/sourceos-shell-pdf-config-contract.nix`

## Updated files

- `modules/nixos/sourceos-shell/default.nix`
- `flake.nix`
- `docs/sourceos-shell-pdf-stack.md`

## What it does

- realizes `/etc/sourceos-shell/pdf-stack.json`
- records the relationship between:
  - `sourceos-docd`
  - `sourceos-pdf-secure`
- records PDF-lane invariants in the realized config
- adds a dedicated contract-style check for the realized PDF config surface
- wires that check into `flake.nix`
- updates the PDF stack note to mention the realized config and both contract checks

## Why

The previous PDF-lane PR added a Linux-side contract check for the `docd` and `pdf-secure` scaffolds. This follow-on patch connects that lane to a realized machine-facing config surface so the Linux realization expresses more than just service presence.

## Related tracker

- `source-os#93` — Track PDF derivation, signing, validation, and viewing lane for sourceos-shell rollout

## Stack relationship

This PR is stacked on top of:
- `source-os#97`

## Follow-on

- replace placeholder service ownership once `SourceOS-Linux/sourceos-shell` exists
- add executable runtime checks for derive/sign/validate behavior
- bind the eventual viewer/runtime behavior to the typed artifact/report contracts already merged in `sourceos-spec`
