### PR TITLE
build(source-os): add SourceOS office shell installer wrapper (ready)

### DIFF
--- a/build/office-suite/scripts/install_sourceos_office_shell.sh
+++ b/build/office-suite/scripts/install_sourceos_office_shell.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+
+"$ROOT/build/office-suite/scripts/install_office_desktop_entry.sh"
+"$ROOT/build/office-suite/scripts/verify_office_desktop_entry.sh"
+
+if [[ -x "$ROOT/build/office-suite/scripts/verify_office_suite_profile.sh" ]]; then
+  "$ROOT/build/office-suite/scripts/verify_office_suite_profile.sh"
+fi
+
+echo "SourceOS office shell install completed"


### PR DESCRIPTION
## Summary

Replacement non-draft PR for the SourceOS office-shell installer wrapper.

Files:
- `build/office-suite/scripts/install_sourceos_office_shell.sh`

## Why

The draft PR is blocked only by the connector's ready-for-review transition bug. This replacement carries the same content on a non-draft branch so review/merge can proceed.
