### PR TITLE
build(source-os): harden office shell installer path (ready)

### DIFF
--- a/build/office-suite/scripts/install_office_desktop_entry.sh
+++ b/build/office-suite/scripts/install_office_desktop_entry.sh
@@ -4,16 +4,19 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 DESKTOP_SRC="$ROOT/build/office-suite/desktop/sourceos-office.desktop"
 BIN_SRC="$ROOT/build/office-suite/scripts/office_open.sh"
+CLOUD_SRC="$ROOT/build/office-suite/scripts/office_cloud_handoff.sh"
 APP_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/applications"
 BIN_DIR="$HOME/.local/bin"
 
 mkdir -p "$APP_DIR" "$BIN_DIR"
 cp "$DESKTOP_SRC" "$APP_DIR/sourceos-office.desktop"
 cp "$BIN_SRC" "$BIN_DIR/sourceos-office-open"
-chmod +x "$BIN_DIR/sourceos-office-open"
+cp "$CLOUD_SRC" "$BIN_DIR/office_cloud_handoff.sh"
+chmod +x "$BIN_DIR/sourceos-office-open" "$BIN_DIR/office_cloud_handoff.sh"
 
 "$ROOT/build/office-suite/scripts/install_office_mime_defaults.sh" >/dev/null
 
 echo "installed desktop entry to $APP_DIR/sourceos-office.desktop"
 echo "installed launcher helper to $BIN_DIR/sourceos-office-open"
+echo "installed cloud handoff helper to $BIN_DIR/office_cloud_handoff.sh"
 echo "installed office MIME defaults"

--- a/build/office-suite/scripts/install_sourceos_office_shell_smoke.sh
+++ b/build/office-suite/scripts/install_sourceos_office_shell_smoke.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+export XDG_DATA_HOME="$TMPDIR/share"
+export XDG_CONFIG_HOME="$TMPDIR/config"
+export HOME="$TMPDIR/home"
+mkdir -p "$HOME"
+
+"$ROOT/build/office-suite/scripts/install_sourceos_office_shell.sh" >/dev/null
+
+DESKTOP_FILE="$XDG_DATA_HOME/applications/sourceos-office.desktop"
+OPEN_BIN="$HOME/.local/bin/sourceos-office-open"
+CLOUD_BIN="$HOME/.local/bin/office_cloud_handoff.sh"
+MIME_FILE="$XDG_CONFIG_HOME/mimeapps.list"
+
+[[ -f "$DESKTOP_FILE" ]] || {
+  echo "office shell installer smoke failed: missing desktop entry" >&2
+  exit 1
+}
+
+[[ -x "$OPEN_BIN" ]] || {
+  echo "office shell installer smoke failed: missing office open launcher" >&2
+  exit 1
+}
+
+[[ -x "$CLOUD_BIN" ]] || {
+  echo "office shell installer smoke failed: missing cloud handoff helper" >&2
+  exit 1
+}
+
+[[ -f "$MIME_FILE" ]] || {
+  echo "office shell installer smoke failed: missing MIME defaults" >&2
+  exit 1
+}
+
+echo "office shell installer smoke passed"


### PR DESCRIPTION
## Summary

Replacement non-draft PR for the office-shell install hardening slice.

Files:
- `build/office-suite/scripts/install_office_desktop_entry.sh`
- `build/office-suite/scripts/install_sourceos_office_shell_smoke.sh`
