### PR TITLE
build(source-os): add office shell verify wrapper

### DIFF
--- a/build/office-suite/scripts/office_shell_verify.sh
+++ b/build/office-suite/scripts/office_shell_verify.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+
+"$ROOT/build/office-suite/scripts/verify_office_desktop_entry.sh"
+
+if [[ -x "$ROOT/build/office-suite/scripts/verify_office_suite_profile.sh" ]]; then
+  "$ROOT/build/office-suite/scripts/verify_office_suite_profile.sh"
+fi
+
+if [[ -x "$ROOT/build/office-suite/scripts/install_sourceos_office_shell_smoke.sh" ]]; then
+  "$ROOT/build/office-suite/scripts/install_sourceos_office_shell_smoke.sh"
+fi
+
+echo "office shell verification passed"


### PR DESCRIPTION
## Summary

Add a single verification wrapper for the SourceOS office shell.

Files:
- `build/office-suite/scripts/office_shell_verify.sh`

## Why

The office shell now has:
- desktop-entry verification
- host/profile verification
- install smoke

This follow-on adds one explicit verification entrypoint that chains those existing checks together.
