### PR TITLE
build(source-os): add sourceos-office command wrapper

### DIFF
--- a/build/office-suite/scripts/sourceos-office
+++ b/build/office-suite/scripts/sourceos-office
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+CMD="${1:-help}"
+shift || true
+
+case "$CMD" in
+  install)
+    "$ROOT/build/office-suite/scripts/install_sourceos_office_shell.sh"
+    ;;
+  verify)
+    "$ROOT/build/office-suite/scripts/office_shell_verify.sh"
+    ;;
+  open)
+    "$ROOT/build/office-suite/scripts/office_open.sh" "$@"
+    ;;
+  search)
+    "$ROOT/build/office-suite/scripts/office_search_open.sh" "$@"
+    ;;
+  help|*)
+    cat <<'EOF'
+usage: sourceos-office <install|verify|open|search> [args]
+EOF
+    ;;
+esac

--- a/build/office-suite/scripts/sourceos_office_smoke.sh
+++ b/build/office-suite/scripts/sourceos_office_smoke.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+OUT="$($ROOT/build/office-suite/scripts/sourceos-office help)"
+
+[[ "$OUT" == *"usage: sourceos-office"* ]] || {
+  echo "sourceos-office smoke failed" >&2
+  exit 1
+}
+
+echo "sourceos-office smoke passed"


### PR DESCRIPTION
## Summary

Add a single command wrapper for the SourceOS office shell.

Files:
- `build/office-suite/scripts/sourceos-office`
- `build/office-suite/scripts/sourceos_office_smoke.sh`

## Why

The office shell already has separate helpers for:
- install
- verify
- open
- search

This follow-on adds one front-door command so the host line is easier to use and easier to document.
