### PR TITLE
build(source-os): add sourceos-office command wrapper (ready)

### DIFF
--- a/build/office-suite/scripts/sourceos-office
+++ b/build/office-suite/scripts/sourceos-office
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+CMD="${1:-help}"
+shift || true
+
+case "$CMD" in
+  install)
+    "$ROOT/build/office-suite/scripts/install_sourceos_office_shell.sh"
+    ;;
+  verify)
+    "$ROOT/build/office-suite/scripts/office_shell_verify.sh"
+    ;;
+  open)
+    "$ROOT/build/office-suite/scripts/office_open.sh" "$@"
+    ;;
+  search)
+    "$ROOT/build/office-suite/scripts/office_search_open.sh" "$@"
+    ;;
+  help|*)
+    cat <<'EOF'
+usage: sourceos-office <install|verify|open|search> [args]
+EOF
+    ;;
+esac

--- a/build/office-suite/scripts/sourceos_office_smoke.sh
+++ b/build/office-suite/scripts/sourceos_office_smoke.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+OUT="$($ROOT/build/office-suite/scripts/sourceos-office help)"
+
+[[ "$OUT" == *"usage: sourceos-office"* ]] || {
+  echo "sourceos-office smoke failed" >&2
+  exit 1
+}
+
+echo "sourceos-office smoke passed"


### PR DESCRIPTION
## Summary

Replacement non-draft PR for the `sourceos-office` command wrapper slice.

Files:
- `build/office-suite/scripts/sourceos-office`
- `build/office-suite/scripts/sourceos_office_smoke.sh`

## Why

The draft PR is blocked only by the connector's ready-for-review transition bug. This replacement carries the same content on a non-draft branch so review/merge can proceed.
