### PR TITLE
test(workstation): add mac-like GNOME defaults contract check

### DIFF
--- a/tests/workstation-mac-defaults-contract.nix
+++ b/tests/workstation-mac-defaults-contract.nix
@@ -1,0 +1,16 @@
+{ pkgs ? import <nixpkgs> {} }:
+pkgs.runCommand "workstation-mac-defaults-contract" {
+  nativeBuildInputs = [ pkgs.gnugrep ];
+} ''
+  test -f ${../profiles/linux-dev/workstation-v0/gnome/mac-defaults.sh}
+  grep -q "enable-hot-corners false" ${../profiles/linux-dev/workstation-v0/gnome/mac-defaults.sh}
+  grep -q "clock-format '12h'" ${../profiles/linux-dev/workstation-v0/gnome/mac-defaults.sh}
+  grep -q "locate-pointer true" ${../profiles/linux-dev/workstation-v0/gnome/mac-defaults.sh}
+  grep -q "click-policy 'double'" ${../profiles/linux-dev/workstation-v0/gnome/mac-defaults.sh}
+  grep -q "show-delete-permanently true" ${../profiles/linux-dev/workstation-v0/gnome/mac-defaults.sh}
+  grep -q "favorite-apps" ${../profiles/linux-dev/workstation-v0/gnome/mac-defaults.sh}
+  grep -q 'set_custom_binding custom1 "SourceOS Files"' ${../profiles/linux-dev/workstation-v0/gnome/mac-defaults.sh}
+  grep -q 'set_custom_binding custom2 "SourceOS Terminal"' ${../profiles/linux-dev/workstation-v0/gnome/mac-defaults.sh}
+  mkdir -p $out
+  echo validated > $out/result.txt
+''


### PR DESCRIPTION
## Summary

Add the first dedicated validation check for the already-merged workstation mac-like GNOME defaults substrate.

## Added files

- `tests/workstation-mac-defaults-contract.nix`

## What it does

- verifies that `profiles/linux-dev/workstation-v0/gnome/mac-defaults.sh` exists
- checks that the script still records the first GNOME desktop behavior slice, including:
  - hot corners disabled
  - 12h clock
  - locate pointer enabled
  - Nautilus double-click policy
  - permanent delete affordance
  - dock favorites seed
  - Files binding on `Super+E`
  - Terminal binding on `Super+Return`

## Why

The GTK/desktop lane already has real merged substrate on `main`, but it did not yet have a dedicated validation artifact making that behavior slice explicit. This PR adds the first repo-side check for that lane without redoing the underlying implementation.

## Related tracker

- `source-os#102` — GTK/desktop lane: add workstation mac-defaults validation check

## Follow-on

- wire this check into the repo validation surface
- update workstation docs to mention the validation hook
- continue the GTK/desktop lane by targeting the remaining desktop/toolkit parity gaps rather than duplicating what is already merged
