### PR TITLE
workstation-v0 Mac polish validation helper

### DIFF
--- a/.github/workflows/workstation-mac-polish.yml
+++ b/.github/workflows/workstation-mac-polish.yml
@@ -3,6 +3,7 @@ name: workstation-mac-polish
 on:
   pull_request:
     paths:
+      - 'profiles/linux-dev/workstation-v0/bin/check-mac-polish.sh'
       - 'profiles/linux-dev/workstation-v0/bin/mac-screenshot.sh'
       - 'profiles/linux-dev/workstation-v0/bin/install-sourceos-cli.sh'
       - 'profiles/linux-dev/workstation-v0/gnome/mac-defaults.sh'
@@ -14,6 +15,7 @@ on:
     branches:
       - main
     paths:
+      - 'profiles/linux-dev/workstation-v0/bin/check-mac-polish.sh'
       - 'profiles/linux-dev/workstation-v0/bin/mac-screenshot.sh'
       - 'profiles/linux-dev/workstation-v0/bin/install-sourceos-cli.sh'
       - 'profiles/linux-dev/workstation-v0/gnome/mac-defaults.sh'
@@ -32,6 +34,7 @@ jobs:
       - name: Syntax check Mac polish scripts
         run: |
           set -euo pipefail
+          bash -n profiles/linux-dev/workstation-v0/bin/check-mac-polish.sh
           bash -n profiles/linux-dev/workstation-v0/bin/mac-screenshot.sh
           bash -n profiles/linux-dev/workstation-v0/bin/install-sourceos-cli.sh
           bash -n profiles/linux-dev/workstation-v0/gnome/mac-defaults.sh
@@ -45,3 +48,30 @@ jobs:
           test -x "$tmp_home/.local/bin/sourceos"
           test -x "$tmp_home/.local/bin/mac-screenshot.sh"
           test -s "$tmp_home/.config/sourceos/profile.path"
+
+      - name: Smoke: Mac polish check helper reports expected keys
+        run: |
+          set -euo pipefail
+          helper='profiles/linux-dev/workstation-v0/bin/check-mac-polish.sh'
+          stub_bin=$(mktemp -d)
+          tmp_home=$(mktemp -d)
+          mkdir -p "$tmp_home/Pictures/Screenshots"
+          cat > "$stub_bin/gnome-screenshot" <<'EOF'
+          #!/usr/bin/env bash
+          exit 0
+          EOF
+          cat > "$stub_bin/sushi" <<'EOF'
+          #!/usr/bin/env bash
+          exit 0
+          EOF
+          cat > "$stub_bin/mac-screenshot.sh" <<'EOF'
+          #!/usr/bin/env bash
+          exit 0
+          EOF
+          chmod +x "$stub_bin/gnome-screenshot" "$stub_bin/sushi" "$stub_bin/mac-screenshot.sh"
+          out=$(HOME="$tmp_home" PATH="$stub_bin:$PATH" bash "$helper")
+          grep -F 'screenshot_helper=present' <<<"$out" >/dev/null
+          grep -F 'screenshot_wrapper=present' <<<"$out" >/dev/null
+          grep -F 'gnome_screenshot=present' <<<"$out" >/dev/null
+          grep -F 'sushi=present' <<<"$out" >/dev/null
+          grep -F 'screenshot_dir=present' <<<"$out" >/dev/null

--- a/profiles/linux-dev/workstation-v0/bin/check-mac-polish.sh
+++ b/profiles/linux-dev/workstation-v0/bin/check-mac-polish.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Lightweight Mac-polish validation helper for workstation-v0.
+# Emits key=value lines so doctor/status can consume it without extra tooling.
+
+have(){ command -v "$1" >/dev/null 2>&1; }
+
+profile_dir(){
+  cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd
+}
+
+screenshot_dir(){
+  printf '%s\n' "${SOURCEOS_SCREENSHOT_DIR:-$HOME/Pictures/Screenshots}"
+}
+
+binding_value(){
+  local slot=$1
+  local base="/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/"
+  local path="${base}${slot}/"
+  if have gsettings; then
+    gsettings get org.gnome.settings-daemon.plugins.media-keys.custom-keybinding:${path} binding 2>/dev/null || true
+  fi
+}
+
+contains_binding_slot(){
+  local slot=$1
+  if have gsettings; then
+    gsettings get org.gnome.settings-daemon.plugins.media-keys custom-keybindings 2>/dev/null | grep -Fq "$slot" && return 0
+  fi
+  return 1
+}
+
+print_present(){
+  local key=$1
+  local path=$2
+  if [[ -e "$path" ]]; then
+    printf '%s=present\n' "$key"
+  else
+    printf '%s=missing\n' "$key"
+  fi
+}
+
+main(){
+  local pdir sdir
+  pdir="$(profile_dir)"
+  sdir="$(screenshot_dir)"
+
+  printf 'profile_dir=%s\n' "$pdir"
+  print_present screenshot_helper "$pdir/bin/mac-screenshot.sh"
+
+  if have mac-screenshot.sh; then
+    printf 'screenshot_wrapper=present\n'
+  else
+    printf 'screenshot_wrapper=missing\n'
+  fi
+
+  if have gnome-screenshot; then
+    printf 'gnome_screenshot=present\n'
+  else
+    printf 'gnome_screenshot=missing\n'
+  fi
+
+  if have sushi; then
+    printf 'sushi=present\n'
+  else
+    printf 'sushi=missing\n'
+  fi
+
+  if [[ -d "$sdir" ]]; then
+    printf 'screenshot_dir=present\n'
+  else
+    printf 'screenshot_dir=missing\n'
+  fi
+  printf 'screenshot_dir_path=%s\n' "$sdir"
+
+  if have gsettings; then
+    printf 'gsettings=present\n'
+    for slot in custom3 custom4 custom5 custom6; do
+      if contains_binding_slot "$slot"; then
+        printf '%s_slot=present\n' "$slot"
+      else
+        printf '%s_slot=missing\n' "$slot"
+      fi
+      printf '%s_binding=%s\n' "$slot" "$(binding_value "$slot")"
+    done
+  else
+    printf 'gsettings=missing\n'
+  fi
+}
+
+main "$@"


### PR DESCRIPTION
Small follow-up after #111.

Adds:
- `check-mac-polish.sh` helper for Mac polish validation
- CI smoke coverage for the helper

The helper reports screenshot helper/wrapper, `gnome-screenshot`, `sushi`, screenshot directory, and GNOME custom binding visibility as key=value lines so it can be wired into doctor/status later with low churn.