### PR TITLE
workstation-v0 bounded GNOME appearance and sidebar polish

### DIFF
--- a/.github/workflows/workstation-mac-polish.yml
+++ b/.github/workflows/workstation-mac-polish.yml
@@ -6,6 +6,8 @@ on:
       - 'profiles/linux-dev/workstation-v0/bin/check-mac-polish.sh'
       - 'profiles/linux-dev/workstation-v0/bin/mac-screenshot.sh'
       - 'profiles/linux-dev/workstation-v0/bin/install-sourceos-cli.sh'
+      - 'profiles/linux-dev/workstation-v0/gnome/appearance-apply.sh'
+      - 'profiles/linux-dev/workstation-v0/gnome/files-sidebar.sh'
       - 'profiles/linux-dev/workstation-v0/gnome/mac-defaults.sh'
       - 'profiles/linux-dev/workstation-v0/gnome/README.md'
       - 'profiles/linux-dev/workstation-v0/manifest.yaml'
@@ -18,6 +20,8 @@ on:
       - 'profiles/linux-dev/workstation-v0/bin/check-mac-polish.sh'
       - 'profiles/linux-dev/workstation-v0/bin/mac-screenshot.sh'
       - 'profiles/linux-dev/workstation-v0/bin/install-sourceos-cli.sh'
+      - 'profiles/linux-dev/workstation-v0/gnome/appearance-apply.sh'
+      - 'profiles/linux-dev/workstation-v0/gnome/files-sidebar.sh'
       - 'profiles/linux-dev/workstation-v0/gnome/mac-defaults.sh'
       - 'profiles/linux-dev/workstation-v0/gnome/README.md'
       - 'profiles/linux-dev/workstation-v0/manifest.yaml'
@@ -37,6 +41,8 @@ jobs:
           bash -n profiles/linux-dev/workstation-v0/bin/check-mac-polish.sh
           bash -n profiles/linux-dev/workstation-v0/bin/mac-screenshot.sh
           bash -n profiles/linux-dev/workstation-v0/bin/install-sourceos-cli.sh
+          bash -n profiles/linux-dev/workstation-v0/gnome/appearance-apply.sh
+          bash -n profiles/linux-dev/workstation-v0/gnome/files-sidebar.sh
           bash -n profiles/linux-dev/workstation-v0/gnome/mac-defaults.sh
 
       - name: Smoke: installer writes user wrappers
@@ -48,6 +54,17 @@ jobs:
           test -x "$tmp_home/.local/bin/sourceos"
           test -x "$tmp_home/.local/bin/mac-screenshot.sh"
           test -s "$tmp_home/.config/sourceos/profile.path"
+
+      - name: Smoke: sidebar helper writes bookmarks
+        run: |
+          set -euo pipefail
+          helper='profiles/linux-dev/workstation-v0/gnome/files-sidebar.sh'
+          tmp_home=$(mktemp -d)
+          HOME="$tmp_home" XDG_CONFIG_HOME="$tmp_home/.config" bash "$helper"
+          bookmarks="$tmp_home/.config/gtk-3.0/bookmarks"
+          test -s "$bookmarks"
+          grep -F 'Documents' "$bookmarks" >/dev/null
+          grep -F 'Screenshots' "$bookmarks" >/dev/null
 
       - name: Smoke: Mac polish check helper reports expected keys
         run: |

--- a/profiles/linux-dev/workstation-v0/gnome/README.md
+++ b/profiles/linux-dev/workstation-v0/gnome/README.md
@@ -14,6 +14,8 @@ Principles:
 ```bash
 ./apply.sh
 ./extensions-install.sh
+./appearance-apply.sh
+./files-sidebar.sh
 ./mac-defaults.sh
 ```
 
@@ -39,8 +41,16 @@ Principles:
 - `Super+Shift+5` interactive screenshot UI
 - `Super+Shift+6` open screenshot directory
 
+## Appearance/sidebar polish v1
+
+This lane adds bounded visual/workflow polish without replacing GNOME Shell or libadwaita:
+
+- `appearance-apply.sh` applies stable GNOME interface settings such as color-scheme preference, cursor size, font antialiasing, overlay scrolling, and primary-selection paste behavior.
+- `files-sidebar.sh` seeds GTK/Nautilus bookmarks for Desktop, Documents, Downloads, Pictures, Screenshots, Music, Videos, and Public.
+- The workstation installer runs both helpers best-effort after the extension pinset and before input/gesture setup.
+
 ## Follow-on work
 
 - Wayland-safe keyboard remap lane expansion
-- Optional bounded icon/cursor/font appearance pack
+- Optional bounded icon/cursor/font package set
 - More complete macOS-style shortcut map after validation

--- a/profiles/linux-dev/workstation-v0/gnome/appearance-apply.sh
+++ b/profiles/linux-dev/workstation-v0/gnome/appearance-apply.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Apply bounded GNOME appearance defaults for workstation-v0.
+# This intentionally avoids replacing GNOME Shell, libadwaita, or requiring
+# proprietary fonts/themes. It only applies stable GNOME interface settings.
+
+info(){ printf "INFO: %s\n" "$*" >&2; }
+warn(){ printf "WARN: %s\n" "$*" >&2; }
+
+have(){ command -v "$1" >/dev/null 2>&1; }
+
+is_gnome(){
+  [[ "${XDG_CURRENT_DESKTOP:-}" == *GNOME* ]] && return 0
+  [[ "${DESKTOP_SESSION:-}" == *gnome* ]] && return 0
+  return 1
+}
+
+set_if_writable(){
+  local schema=$1
+  local key=$2
+  shift 2
+  if ! have gsettings; then
+    return 0
+  fi
+  if gsettings writable "$schema" "$key" >/dev/null 2>&1; then
+    gsettings set "$schema" "$key" "$@" >/dev/null || true
+    info "set: $schema $key"
+  else
+    warn "not writable or missing: $schema $key"
+  fi
+}
+
+main(){
+  if ! have gsettings; then
+    warn "gsettings not found; skipping appearance defaults"
+    exit 0
+  fi
+
+  if ! is_gnome; then
+    warn "GNOME not detected; skipping appearance defaults"
+    exit 0
+  fi
+
+  local color_scheme="${SOURCEOS_GNOME_COLOR_SCHEME:-default}"
+  case "$color_scheme" in
+    default|prefer-dark|prefer-light) ;;
+    *)
+      warn "invalid SOURCEOS_GNOME_COLOR_SCHEME=$color_scheme; using default"
+      color_scheme="default"
+      ;;
+  esac
+
+  info "Applying bounded GNOME appearance defaults"
+
+  set_if_writable org.gnome.desktop.interface color-scheme "'$color_scheme'"
+  set_if_writable org.gnome.desktop.interface cursor-size 24
+  set_if_writable org.gnome.desktop.interface text-scaling-factor 1.0
+  set_if_writable org.gnome.desktop.interface gtk-enable-primary-paste false
+  set_if_writable org.gnome.desktop.interface overlay-scrolling true
+  set_if_writable org.gnome.desktop.interface font-antialiasing "'grayscale'"
+  set_if_writable org.gnome.desktop.interface font-hinting "'slight'"
+  set_if_writable org.gnome.desktop.wm.preferences titlebar-font "'Cantarell Bold 11'"
+
+  info "GNOME appearance defaults applied"
+}
+
+main "$@"

--- a/profiles/linux-dev/workstation-v0/gnome/files-sidebar.sh
+++ b/profiles/linux-dev/workstation-v0/gnome/files-sidebar.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Seed GTK/Nautilus sidebar bookmarks for a Finder-like baseline.
+# Safe to run repeatedly.
+
+info(){ printf "INFO: %s\n" "$*" >&2; }
+
+bookmarks_file(){
+  printf '%s/gtk-3.0/bookmarks\n' "${XDG_CONFIG_HOME:-$HOME/.config}"
+}
+
+uri_for(){
+  local path=$1
+  python3 - "$path" <<'PY'
+import pathlib, sys
+print(pathlib.Path(sys.argv[1]).expanduser().resolve().as_uri())
+PY
+}
+
+ensure_bookmark(){
+  local path=$1
+  local label=$2
+  local f uri line
+  f="$(bookmarks_file)"
+  uri="$(uri_for "$path")"
+  line="$uri $label"
+  mkdir -p "$(dirname "$f")"
+  touch "$f"
+  if ! grep -Fqx "$line" "$f"; then
+    printf '%s\n' "$line" >> "$f"
+    info "bookmark: $label -> $path"
+  fi
+}
+
+main(){
+  mkdir -p "$HOME/Desktop" "$HOME/Documents" "$HOME/Downloads" "$HOME/Pictures" "$HOME/Pictures/Screenshots" "$HOME/Music" "$HOME/Videos" "$HOME/Public"
+
+  ensure_bookmark "$HOME/Desktop" Desktop
+  ensure_bookmark "$HOME/Documents" Documents
+  ensure_bookmark "$HOME/Downloads" Downloads
+  ensure_bookmark "$HOME/Pictures" Pictures
+  ensure_bookmark "$HOME/Pictures/Screenshots" Screenshots
+  ensure_bookmark "$HOME/Music" Music
+  ensure_bookmark "$HOME/Videos" Videos
+  ensure_bookmark "$HOME/Public" Public
+}
+
+main "$@"

--- a/profiles/linux-dev/workstation-v0/install.sh
+++ b/profiles/linux-dev/workstation-v0/install.sh
@@ -135,9 +135,9 @@ apply_gnome_extensions(){
 
 apply_gnome_appearance(){
   local script="$PROFILE_DIR/gnome/appearance-apply.sh"
-  if [[ -x "$script" ]]; then
+  if [[ -f "$script" ]]; then
     info "Applying GNOME appearance defaults (best-effort)"
-    "$script" || warn "GNOME appearance defaults failed (non-fatal)"
+    bash "$script" || warn "GNOME appearance defaults failed (non-fatal)"
   else
     warn "GNOME appearance script not found: $script"
   fi
@@ -145,9 +145,9 @@ apply_gnome_appearance(){
 
 apply_files_sidebar(){
   local script="$PROFILE_DIR/gnome/files-sidebar.sh"
-  if [[ -x "$script" ]]; then
+  if [[ -f "$script" ]]; then
     info "Applying Files sidebar defaults (best-effort)"
-    "$script" || warn "Files sidebar defaults failed (non-fatal)"
+    bash "$script" || warn "Files sidebar defaults failed (non-fatal)"
   else
     warn "Files sidebar script not found: $script"
   fi

--- a/profiles/linux-dev/workstation-v0/install.sh
+++ b/profiles/linux-dev/workstation-v0/install.sh
@@ -133,6 +133,26 @@ apply_gnome_extensions(){
   fi
 }
 
+apply_gnome_appearance(){
+  local script="$PROFILE_DIR/gnome/appearance-apply.sh"
+  if [[ -x "$script" ]]; then
+    info "Applying GNOME appearance defaults (best-effort)"
+    "$script" || warn "GNOME appearance defaults failed (non-fatal)"
+  else
+    warn "GNOME appearance script not found: $script"
+  fi
+}
+
+apply_files_sidebar(){
+  local script="$PROFILE_DIR/gnome/files-sidebar.sh"
+  if [[ -x "$script" ]]; then
+    info "Applying Files sidebar defaults (best-effort)"
+    "$script" || warn "Files sidebar defaults failed (non-fatal)"
+  else
+    warn "Files sidebar script not found: $script"
+  fi
+}
+
 apply_input_install(){
   local script="$PROFILE_DIR/gnome/input-install.sh"
   if [[ -x "$script" ]]; then
@@ -203,6 +223,8 @@ main(){
   patch_shell_rc_if_enabled
   apply_gnome_baseline
   apply_gnome_extensions
+  apply_gnome_appearance
+  apply_files_sidebar
   apply_input_install
   apply_fusuma_install
   apply_fusuma_config


### PR DESCRIPTION
Follow-up after #111/#112 for the Mac-on-Linux GNOME lane.

Adds bounded appearance/workflow polish:
- `appearance-apply.sh` for stable GNOME interface defaults without shell/theme replacement
- `files-sidebar.sh` for Finder-like GTK/Nautilus bookmarks
- installer wiring for both helpers using `bash` to avoid executable-bit drift
- CI smoke coverage for appearance/sidebar helper syntax and sidebar bookmark output
- GNOME README documentation for the bounded appearance/sidebar lane

This deliberately avoids fragile shell theming and keeps the polish inside GNOME settings, package components, and helper scripts.