### PR TITLE
workstation-v0 aggregate polish validation helper

### DIFF
--- a/.github/workflows/workstation-polish-validation.yml
+++ b/.github/workflows/workstation-polish-validation.yml
@@ -1,0 +1,67 @@
+name: workstation-polish-validation
+
+on:
+  pull_request:
+    paths:
+      - 'profiles/linux-dev/workstation-v0/bin/check-workstation-polish.sh'
+      - 'profiles/linux-dev/workstation-v0/bin/check-mac-polish.sh'
+      - 'profiles/linux-dev/workstation-v0/bin/check-keyboard-policy.sh'
+      - '.github/workflows/workstation-polish-validation.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'profiles/linux-dev/workstation-v0/bin/check-workstation-polish.sh'
+      - 'profiles/linux-dev/workstation-v0/bin/check-mac-polish.sh'
+      - 'profiles/linux-dev/workstation-v0/bin/check-keyboard-policy.sh'
+      - '.github/workflows/workstation-polish-validation.yml'
+
+jobs:
+  polish-validation-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Syntax check aggregate helper
+        run: |
+          set -euo pipefail
+          bash -n profiles/linux-dev/workstation-v0/bin/check-workstation-polish.sh
+          bash -n profiles/linux-dev/workstation-v0/bin/check-mac-polish.sh
+          bash -n profiles/linux-dev/workstation-v0/bin/check-keyboard-policy.sh
+
+      - name: Smoke: aggregate helper prefixes Mac and keyboard policy outputs
+        run: |
+          set -euo pipefail
+          helper='profiles/linux-dev/workstation-v0/bin/check-workstation-polish.sh'
+          tmp_home=$(mktemp -d)
+          stub_bin=$(mktemp -d)
+          mkdir -p "$tmp_home/Pictures/Screenshots"
+          cat > "$stub_bin/gnome-screenshot" <<'EOF'
+          #!/usr/bin/env bash
+          exit 0
+          EOF
+          cat > "$stub_bin/sushi" <<'EOF'
+          #!/usr/bin/env bash
+          exit 0
+          EOF
+          cat > "$stub_bin/mac-screenshot.sh" <<'EOF'
+          #!/usr/bin/env bash
+          exit 0
+          EOF
+          cat > "$stub_bin/input-remapper-control" <<'EOF'
+          #!/usr/bin/env bash
+          exit 0
+          EOF
+          chmod +x "$stub_bin/gnome-screenshot" "$stub_bin/sushi" "$stub_bin/mac-screenshot.sh" "$stub_bin/input-remapper-control"
+
+          out=$(HOME="$tmp_home" XDG_CONFIG_HOME="$tmp_home/.config" PATH="$stub_bin:$PATH" bash "$helper")
+          grep -F 'mac_polish.helper=present' <<<"$out" >/dev/null
+          grep -F 'mac_polish.screenshot_helper=present' <<<"$out" >/dev/null
+          grep -F 'mac_polish.screenshot_wrapper=present' <<<"$out" >/dev/null
+          grep -F 'mac_polish.sushi=present' <<<"$out" >/dev/null
+          grep -F 'keyboard_policy.helper=present' <<<"$out" >/dev/null
+          grep -F 'keyboard_policy.default_backend=input-remapper' <<<"$out" >/dev/null
+          grep -F 'keyboard_policy.primary_backend=input-remapper' <<<"$out" >/dev/null
+          grep -F 'keyboard_policy.selected_backend_available=present' <<<"$out" >/dev/null
+          grep -F 'keyboard_policy.policy_ok=yes' <<<"$out" >/dev/null

--- a/profiles/linux-dev/workstation-v0/bin/check-workstation-polish.sh
+++ b/profiles/linux-dev/workstation-v0/bin/check-workstation-polish.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Aggregate workstation polish validation helper.
+# Consumes small key=value helpers and emits section-prefixed key=value lines.
+# This is intentionally shell-only so it can feed CI, doctor, and status later.
+
+profile_dir(){
+  cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd
+}
+
+emit_section(){
+  local section=$1
+  local helper=$2
+
+  if [[ ! -f "$helper" ]]; then
+    printf '%s.helper=missing\n' "$section"
+    return 0
+  fi
+
+  printf '%s.helper=present\n' "$section"
+  while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+    printf '%s.%s\n' "$section" "$line"
+  done < <(bash "$helper" 2>/dev/null || true)
+}
+
+main(){
+  local pdir
+  pdir="$(profile_dir)"
+  printf 'profile_dir=%s\n' "$pdir"
+  emit_section mac_polish "$pdir/bin/check-mac-polish.sh"
+  emit_section keyboard_policy "$pdir/bin/check-keyboard-policy.sh"
+}
+
+main "$@"


### PR DESCRIPTION
Adds a small aggregate validation helper for workstation polish signals plus CI smoke coverage. This follows the keyboard policy validation work and keeps the branch limited to validation plumbing.