### PR TITLE
build(source-os): stage sourceos-office in shell installer on current main

### DIFF
--- a/build/office-suite/scripts/install_sourceos_office_shell.sh
+++ b/build/office-suite/scripts/install_sourceos_office_shell.sh
@@ -2,12 +2,18 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+BIN_DIR="$HOME/.local/bin"
 
 "$ROOT/build/office-suite/scripts/install_office_desktop_entry.sh"
 "$ROOT/build/office-suite/scripts/verify_office_desktop_entry.sh"
+
+mkdir -p "$BIN_DIR"
+cp "$ROOT/build/office-suite/scripts/sourceos-office" "$BIN_DIR/sourceos-office"
+chmod +x "$BIN_DIR/sourceos-office"
 
 if [[ -x "$ROOT/build/office-suite/scripts/verify_office_suite_profile.sh" ]]; then
   "$ROOT/build/office-suite/scripts/verify_office_suite_profile.sh"
 fi
 
+echo "installed sourceos-office to $BIN_DIR/sourceos-office"
 echo "SourceOS office shell install completed"

--- a/build/office-suite/scripts/install_sourceos_office_shell_smoke.sh
+++ b/build/office-suite/scripts/install_sourceos_office_shell_smoke.sh
@@ -14,6 +14,7 @@ mkdir -p "$HOME"
 
 DESKTOP_FILE="$XDG_DATA_HOME/applications/sourceos-office.desktop"
 OPEN_BIN="$HOME/.local/bin/sourceos-office-open"
+SOURCEOS_OFFICE_BIN="$HOME/.local/bin/sourceos-office"
 CLOUD_BIN="$HOME/.local/bin/office_cloud_handoff.sh"
 MIME_FILE="$XDG_CONFIG_HOME/mimeapps.list"
 
@@ -27,6 +28,11 @@ MIME_FILE="$XDG_CONFIG_HOME/mimeapps.list"
   exit 1
 }
 
+[[ -x "$SOURCEOS_OFFICE_BIN" ]] || {
+  echo "office shell installer smoke failed: missing sourceos-office command" >&2
+  exit 1
+}
+
 [[ -x "$CLOUD_BIN" ]] || {
   echo "office shell installer smoke failed: missing cloud handoff helper" >&2
   exit 1
@@ -34,6 +40,12 @@ MIME_FILE="$XDG_CONFIG_HOME/mimeapps.list"
 
 [[ -f "$MIME_FILE" ]] || {
   echo "office shell installer smoke failed: missing MIME defaults" >&2
+  exit 1
+}
+
+OUT="$($SOURCEOS_OFFICE_BIN help)"
+[[ "$OUT" == *"usage: sourceos-office"* ]] || {
+  echo "office shell installer smoke failed: sourceos-office help mismatch" >&2
   exit 1
 }
 


### PR DESCRIPTION
Closed as already integrated into current `main`.

The two intended files are present on current `main` with the expected SourceOS office shell installer and smoke behavior:

- `build/office-suite/scripts/install_sourceos_office_shell.sh`
- `build/office-suite/scripts/install_sourceos_office_shell_smoke.sh`

No replacement PR is needed.