### PR TITLE
workstation-v0 surface aggregate polish warnings in status

### DIFF
--- a/.github/workflows/workstation-status-polish.yml
+++ b/.github/workflows/workstation-status-polish.yml
@@ -1,0 +1,91 @@
+name: workstation-status-polish
+
+on:
+  pull_request:
+    paths:
+      - 'profiles/linux-dev/workstation-v0/bin/sourceos'
+      - 'profiles/linux-dev/workstation-v0/bin/check-workstation-polish.sh'
+      - '.github/workflows/workstation-status-polish.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'profiles/linux-dev/workstation-v0/bin/sourceos'
+      - 'profiles/linux-dev/workstation-v0/bin/check-workstation-polish.sh'
+      - '.github/workflows/workstation-status-polish.yml'
+
+jobs:
+  status-polish-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Syntax check sourceos helper
+        run: |
+          set -euo pipefail
+          bash -n profiles/linux-dev/workstation-v0/bin/sourceos
+
+      - name: Smoke: status JSON shape survives aggregate polish warnings
+        run: |
+          set -euo pipefail
+          f='profiles/linux-dev/workstation-v0/bin/sourceos'
+          tmp_profile=$(mktemp -d)
+          mkdir -p "$tmp_profile/bin"
+          cp "$f" "$tmp_profile/bin/sourceos"
+          cat > "$tmp_profile/bin/check-workstation-polish.sh" <<'EOF'
+          #!/usr/bin/env bash
+          set -euo pipefail
+          printf 'mac_polish.helper=present\n'
+          printf 'keyboard_policy.helper=present\n'
+          printf 'keyboard_policy.policy_ok=yes\n'
+          EOF
+          chmod +x "$tmp_profile/bin/check-workstation-polish.sh"
+
+          set +e
+          out=$(SOURCEOS_PROFILE_DIR="$tmp_profile" bash "$tmp_profile/bin/sourceos" status --json)
+          rc=$?
+          set -e
+
+          if [ "$rc" -ne 0 ] && [ "$rc" -ne 2 ]; then
+            echo "Unexpected exit code: $rc" >&2
+            exit 1
+          fi
+
+          python3 -c 'import json,sys
+j=json.loads(sys.stdin.read())
+assert set(j)=={"profile","ok","gnome","required_missing","optional_missing","warnings"}, sorted(j)
+assert isinstance(j["warnings"], list)
+print("status-json-schema: ok")' <<<"$out"
+
+      - name: Smoke: invalid aggregate keyboard policy emits warning without schema change
+        run: |
+          set -euo pipefail
+          f='profiles/linux-dev/workstation-v0/bin/sourceos'
+          tmp_profile=$(mktemp -d)
+          mkdir -p "$tmp_profile/bin"
+          cp "$f" "$tmp_profile/bin/sourceos"
+          cat > "$tmp_profile/bin/check-workstation-polish.sh" <<'EOF'
+          #!/usr/bin/env bash
+          set -euo pipefail
+          printf 'mac_polish.helper=present\n'
+          printf 'keyboard_policy.helper=present\n'
+          printf 'keyboard_policy.policy_ok=no\n'
+          EOF
+          chmod +x "$tmp_profile/bin/check-workstation-polish.sh"
+
+          set +e
+          out=$(SOURCEOS_PROFILE_DIR="$tmp_profile" bash "$tmp_profile/bin/sourceos" status --json)
+          rc=$?
+          set -e
+
+          if [ "$rc" -ne 0 ] && [ "$rc" -ne 2 ]; then
+            echo "Unexpected exit code: $rc" >&2
+            exit 1
+          fi
+
+          python3 -c 'import json,sys
+j=json.loads(sys.stdin.read())
+assert set(j)=={"profile","ok","gnome","required_missing","optional_missing","warnings"}, sorted(j)
+assert "keyboard policy is not valid" in j["warnings"]
+print("status-warning: ok")' <<<"$out"

--- a/profiles/linux-dev/workstation-v0/bin/sourceos
+++ b/profiles/linux-dev/workstation-v0/bin/sourceos
@@ -328,6 +328,27 @@ status_check_lampstand_unit(){
   [[ "$active" == "yes" || "$active" == "unknown" ]] || WARNINGS+=("lampstand user unit not active")
 }
 
+status_check_workstation_polish(){
+  local helper="$PROFILE_DIR/bin/check-workstation-polish.sh"
+  local out policy_ok
+
+  if [[ ! -f "$helper" ]]; then
+    WARNINGS+=("missing workstation polish helper: $helper")
+    return
+  fi
+
+  if ! out="$(bash "$helper" 2>/dev/null)"; then
+    WARNINGS+=("workstation polish helper failed")
+    return
+  fi
+
+  grep -Fqx 'mac_polish.helper=present' <<<"$out" || WARNINGS+=("mac polish helper missing")
+  grep -Fqx 'keyboard_policy.helper=present' <<<"$out" || WARNINGS+=("keyboard policy helper missing")
+
+  policy_ok="$(awk -F= '$1=="keyboard_policy.policy_ok" {print $2}' <<<"$out" | tail -n1)"
+  [[ "$policy_ok" == "yes" ]] || WARNINGS+=("keyboard policy is not valid")
+}
+
 status_collect(){
   REQUIRED_MISSING=()
   OPTIONAL_MISSING=()
@@ -355,6 +376,7 @@ status_collect(){
 
   status_check_lampstand
   status_check_lampstand_unit
+  status_check_workstation_polish
 
   if gnome_detect; then
     if ! check_bin gsettings; then


### PR DESCRIPTION
Adds minimal status integration for aggregate workstation polish warnings.

Scope:
- consume `check-workstation-polish.sh` from `sourceos status`
- append warnings only
- preserve existing status JSON shape
- add `workstation-status-polish` smoke workflow

Validation:
- `bash -n profiles/linux-dev/workstation-v0/bin/sourceos`
- status JSON must keep keys: `profile`, `ok`, `gnome`, `required_missing`, `optional_missing`, `warnings`
- invalid aggregate keyboard policy must add a warning without changing JSON shape

Critic notes:
- no `doctor.sh` change
- no unrelated files touched