### PR TITLE
workstation-v0 shortcut map contract

### DIFF
--- a/.github/workflows/workstation-shortcut-map.yml
+++ b/.github/workflows/workstation-shortcut-map.yml
@@ -1,0 +1,47 @@
+name: workstation-shortcut-map
+
+on:
+  pull_request:
+    paths:
+      - 'docs/workstation/shortcut-map.md'
+      - 'profiles/linux-dev/workstation-v0/bin/check-shortcut-map-contract.sh'
+      - '.github/workflows/workstation-shortcut-map.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/workstation/shortcut-map.md'
+      - 'profiles/linux-dev/workstation-v0/bin/check-shortcut-map-contract.sh'
+      - '.github/workflows/workstation-shortcut-map.yml'
+
+jobs:
+  shortcut-map-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Syntax check shortcut map helper
+        run: |
+          set -euo pipefail
+          bash -n profiles/linux-dev/workstation-v0/bin/check-shortcut-map-contract.sh
+
+      - name: Smoke: shortcut map contract helper reports required markers
+        run: |
+          set -euo pipefail
+          helper='profiles/linux-dev/workstation-v0/bin/check-shortcut-map-contract.sh'
+          out=$(bash "$helper")
+          grep -F 'shortcut_map=present' <<<"$out" >/dev/null
+          grep -F 'active_palette=present' <<<"$out" >/dev/null
+          grep -F 'active_files=present' <<<"$out" >/dev/null
+          grep -F 'active_terminal=present' <<<"$out" >/dev/null
+          grep -F 'active_screenshot_screen=present' <<<"$out" >/dev/null
+          grep -F 'active_screenshot_area=present' <<<"$out" >/dev/null
+          grep -F 'active_screenshot_ui=present' <<<"$out" >/dev/null
+          grep -F 'active_screenshot_folder=present' <<<"$out" >/dev/null
+          grep -F 'compatibility_input_remapper=present' <<<"$out" >/dev/null
+          grep -F 'compatibility_xremap=present' <<<"$out" >/dev/null
+          grep -F 'compatibility_kinto=present' <<<"$out" >/dev/null
+          grep -F 'planned_marker=present' <<<"$out" >/dev/null
+          grep -F 'non_goal_marker=present' <<<"$out" >/dev/null
+          grep -F 'boundary_marker=present' <<<"$out" >/dev/null

--- a/docs/workstation/shortcut-map.md
+++ b/docs/workstation/shortcut-map.md
@@ -1,0 +1,54 @@
+# Workstation v0 Shortcut Map Contract
+
+This contract records the current workstation-v0 Mac-on-Linux shortcut surface and separates active bindings from proposed future bindings.
+
+It is documentation and validation guidance only. It does not change active keybindings.
+
+## Active bindings
+
+| Action | Binding | Enforced by | Status |
+|---|---|---|---|
+| SourceOS palette | `Super+Space` | `profiles/linux-dev/workstation-v0/gnome/palette-hotkey.sh` | active |
+| Files / Nautilus | `Super+E` | `profiles/linux-dev/workstation-v0/gnome/mac-defaults.sh` | active |
+| Terminal | `Super+Return` | `profiles/linux-dev/workstation-v0/gnome/mac-defaults.sh` | active |
+| Full-screen screenshot | `Super+Shift+3` | `profiles/linux-dev/workstation-v0/gnome/mac-defaults.sh`; `profiles/linux-dev/workstation-v0/bin/mac-screenshot.sh` | active |
+| Area screenshot | `Super+Shift+4` | `profiles/linux-dev/workstation-v0/gnome/mac-defaults.sh`; `profiles/linux-dev/workstation-v0/bin/mac-screenshot.sh` | active |
+| Interactive screenshot UI | `Super+Shift+5` | `profiles/linux-dev/workstation-v0/gnome/mac-defaults.sh`; `profiles/linux-dev/workstation-v0/bin/mac-screenshot.sh` | active |
+| Screenshots folder | `Super+Shift+6` | `profiles/linux-dev/workstation-v0/gnome/mac-defaults.sh`; `profiles/linux-dev/workstation-v0/bin/mac-screenshot.sh` | active |
+
+## Active compatibility policy
+
+| Lane | Status | Enforced by | Notes |
+|---|---|---|---|
+| `input-remapper` primary backend | active policy | `profiles/linux-dev/workstation-v0/bin/check-keyboard-policy.sh`; `profiles/linux-dev/workstation-v0/gnome/input-install.sh` | Default Fedora/GNOME path. |
+| `xremap` compatibility backend | active compatibility lane | `profiles/linux-dev/workstation-v0/gnome/input-install.sh` | Writes `$XDG_CONFIG_HOME/sourceos/input/xremap-macos-compat.yml` when explicitly selected. |
+| Kinto compatibility | documented compatibility lane | `profiles/linux-dev/workstation-v0/manifest.yaml`; `profiles/linux-dev/workstation-v0/gnome/README.md` | X11/xkeysnail-style compatibility. Not auto-installed in the Wayland-first profile. |
+
+## Proposed future bindings, not active
+
+These are backlog candidates and must not be treated as implemented until a GitHub PR, branch, commit, or merge proves delivery with validation evidence.
+
+| Proposed action | Candidate binding | Status | Notes |
+|---|---|---|---|
+| Spotlight-like global search refinement | `Super+Space` with richer provider routing | planned | Current palette exists; provider richness remains future work. |
+| Mission-control style overview tuning | TBD | planned | Must remain GNOME/Wayland-safe. |
+| App switching parity refinements | TBD | planned | Requires explicit remap policy and validation. |
+| Text-editing macOS modifier parity | TBD | planned | Must be validated per backend; not safe to assume globally. |
+| Full macOS shortcut parity | none | non-goal for v0 | v0 targets bounded GNOME polish, not a clone. |
+
+## Validation commands
+
+```bash
+test -s docs/workstation/shortcut-map.md
+grep -F "Super+Shift+3" docs/workstation/shortcut-map.md
+grep -F "active" docs/workstation/shortcut-map.md
+grep -F "planned" docs/workstation/shortcut-map.md
+grep -F "non-goal" docs/workstation/shortcut-map.md
+```
+
+## Boundaries
+
+- This document does not modify keybindings.
+- Active binding changes belong in `profiles/linux-dev/workstation-v0/gnome/mac-defaults.sh` or `palette-hotkey.sh`.
+- Backend remap changes belong in `profiles/linux-dev/workstation-v0/gnome/input-install.sh` and must be validated by `check-keyboard-policy.sh`.
+- Future parity claims must remain planned until backed by GitHub-visible implementation and validation evidence.

--- a/profiles/linux-dev/workstation-v0/bin/check-shortcut-map-contract.sh
+++ b/profiles/linux-dev/workstation-v0/bin/check-shortcut-map-contract.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Validate the workstation-v0 shortcut map contract without changing bindings.
+# Emits key=value lines for CI/reviewer consumption.
+
+repo_root(){
+  local here
+  here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  cd "$here/../../.." && pwd
+}
+
+present(){
+  local key=$1
+  local pattern=$2
+  local file=$3
+  if grep -Fq "$pattern" "$file" 2>/dev/null; then
+    printf '%s=present\n' "$key"
+  else
+    printf '%s=missing\n' "$key"
+  fi
+}
+
+main(){
+  local root doc
+  root="$(repo_root)"
+  doc="$root/docs/workstation/shortcut-map.md"
+
+  if [[ -s "$doc" ]]; then
+    printf 'shortcut_map=present\n'
+  else
+    printf 'shortcut_map=missing\n'
+    exit 0
+  fi
+
+  present active_palette 'Super+Space' "$doc"
+  present active_files 'Super+E' "$doc"
+  present active_terminal 'Super+Return' "$doc"
+  present active_screenshot_screen 'Super+Shift+3' "$doc"
+  present active_screenshot_area 'Super+Shift+4' "$doc"
+  present active_screenshot_ui 'Super+Shift+5' "$doc"
+  present active_screenshot_folder 'Super+Shift+6' "$doc"
+  present compatibility_input_remapper 'input-remapper' "$doc"
+  present compatibility_xremap 'xremap' "$doc"
+  present compatibility_kinto 'Kinto' "$doc"
+  present planned_marker 'planned' "$doc"
+  present non_goal_marker 'non-goal' "$doc"
+  present boundary_marker 'does not modify keybindings' "$doc"
+}
+
+main "$@"


### PR DESCRIPTION
Closes #126.

What changed:
- Added `docs/workstation/shortcut-map.md`.
- Added `profiles/linux-dev/workstation-v0/bin/check-shortcut-map-contract.sh`.
- Added `workstation-shortcut-map` smoke workflow.

Validation evidence:
- `test -s docs/workstation/shortcut-map.md`
- `grep -F "Super+Shift+3" docs/workstation/shortcut-map.md`
- `bash -n profiles/linux-dev/workstation-v0/bin/check-shortcut-map-contract.sh`
- `bash profiles/linux-dev/workstation-v0/bin/check-shortcut-map-contract.sh`

Known gaps:
- This is a contract/documentation validation PR only.
- It does not implement additional keybindings.

Non-goals preserved:
- No active keybinding changes.
- No remap daemon behavior changes.
- No package manifest changes.