### PR TITLE
workstation-v0 GNOME dock extension validation helper

### DIFF
--- a/.github/workflows/workstation-gnome-dock-validation.yml
+++ b/.github/workflows/workstation-gnome-dock-validation.yml
@@ -1,0 +1,72 @@
+name: workstation-gnome-dock-validation
+
+on:
+  pull_request:
+    paths:
+      - 'profiles/linux-dev/workstation-v0/bin/check-gnome-dock-extension.sh'
+      - 'profiles/linux-dev/workstation-v0/gnome/README.md'
+      - '.github/workflows/workstation-gnome-dock-validation.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'profiles/linux-dev/workstation-v0/bin/check-gnome-dock-extension.sh'
+      - 'profiles/linux-dev/workstation-v0/gnome/README.md'
+      - '.github/workflows/workstation-gnome-dock-validation.yml'
+
+jobs:
+  dock-extension-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Syntax check dock extension helper
+        run: |
+          set -euo pipefail
+          bash -n profiles/linux-dev/workstation-v0/bin/check-gnome-dock-extension.sh
+
+      - name: Smoke: helper emits required keys without GNOME tools
+        run: |
+          set -euo pipefail
+          helper='profiles/linux-dev/workstation-v0/bin/check-gnome-dock-extension.sh'
+          out=$(bash "$helper")
+          grep -F 'gnome_extensions=' <<<"$out" >/dev/null
+          grep -F 'gsettings=' <<<"$out" >/dev/null
+          grep -F 'dash_to_dock=' <<<"$out" >/dev/null
+          grep -F 'appindicator=' <<<"$out" >/dev/null
+          grep -F 'favorite_apps_visibility=' <<<"$out" >/dev/null
+          grep -F 'gnome_dock_extension_lane_ok=' <<<"$out" >/dev/null
+
+      - name: Smoke: helper detects positive extension and favorites state
+        run: |
+          set -euo pipefail
+          helper='profiles/linux-dev/workstation-v0/bin/check-gnome-dock-extension.sh'
+          stub_bin=$(mktemp -d)
+          cat > "$stub_bin/gnome-extensions" <<'EOF'
+          #!/usr/bin/env bash
+          set -euo pipefail
+          if [ "${1:-}" = list ]; then
+            printf 'dash-to-dock@micxgx.gmail.com\n'
+            printf 'appindicatorsupport@rgcjonas.gmail.com\n'
+            exit 0
+          fi
+          exit 2
+          EOF
+          cat > "$stub_bin/gsettings" <<'EOF'
+          #!/usr/bin/env bash
+          set -euo pipefail
+          if [ "${1:-}" = get ] && [ "${2:-}" = org.gnome.shell ] && [ "${3:-}" = favorite-apps ]; then
+            printf "['org.gnome.Nautilus.desktop', 'org.gnome.Terminal.desktop']\n"
+            exit 0
+          fi
+          exit 2
+          EOF
+          chmod +x "$stub_bin/gnome-extensions" "$stub_bin/gsettings"
+          out=$(PATH="$stub_bin:$PATH" bash "$helper")
+          grep -F 'gnome_extensions=present' <<<"$out" >/dev/null
+          grep -F 'gsettings=present' <<<"$out" >/dev/null
+          grep -F 'dash_to_dock=present' <<<"$out" >/dev/null
+          grep -F 'appindicator=present' <<<"$out" >/dev/null
+          grep -F 'favorite_apps_visibility=present' <<<"$out" >/dev/null
+          grep -F 'gnome_dock_extension_lane_ok=yes' <<<"$out" >/dev/null

--- a/profiles/linux-dev/workstation-v0/bin/check-gnome-dock-extension.sh
+++ b/profiles/linux-dev/workstation-v0/bin/check-gnome-dock-extension.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Validate the GNOME dock/extension lane for workstation-v0.
+# Emits key=value lines for CI, status, and doctor integration.
+# This helper is read-only: it does not install or enable extensions.
+
+have(){ command -v "$1" >/dev/null 2>&1; }
+
+extension_present(){
+  local uuid=$1
+  if ! have gnome-extensions; then
+    printf 'unknown\n'
+    return
+  fi
+  if gnome-extensions list 2>/dev/null | grep -Fxq "$uuid"; then
+    printf 'present\n'
+  else
+    printf 'missing\n'
+  fi
+}
+
+favorite_apps_state(){
+  if ! have gsettings; then
+    printf 'unknown\n'
+    return
+  fi
+  local value
+  value="$(gsettings get org.gnome.shell favorite-apps 2>/dev/null || true)"
+  if [[ -z "$value" ]]; then
+    printf 'unknown\n'
+    return
+  fi
+  if grep -Fq 'org.gnome.Nautilus.desktop' <<<"$value" && grep -Fq 'org.gnome.Terminal.desktop' <<<"$value"; then
+    printf 'present\n'
+  else
+    printf 'partial\n'
+  fi
+}
+
+main(){
+  local dash appindicator favorites lane_ok
+  dash="$(extension_present 'dash-to-dock@micxgx.gmail.com')"
+  appindicator="$(extension_present 'appindicatorsupport@rgcjonas.gmail.com')"
+  favorites="$(favorite_apps_state)"
+  lane_ok=no
+
+  if have gnome-extensions; then
+    printf 'gnome_extensions=present\n'
+  else
+    printf 'gnome_extensions=missing\n'
+  fi
+
+  if have gsettings; then
+    printf 'gsettings=present\n'
+  else
+    printf 'gsettings=missing\n'
+  fi
+
+  printf 'dash_to_dock=%s\n' "$dash"
+  printf 'appindicator=%s\n' "$appindicator"
+  printf 'favorite_apps_visibility=%s\n' "$favorites"
+
+  if [[ "$dash" == "present" && "$appindicator" == "present" && "$favorites" == "present" ]]; then
+    lane_ok=yes
+  fi
+  printf 'gnome_dock_extension_lane_ok=%s\n' "$lane_ok"
+}
+
+main "$@"

--- a/profiles/linux-dev/workstation-v0/gnome/README.md
+++ b/profiles/linux-dev/workstation-v0/gnome/README.md
@@ -59,6 +59,25 @@ The workstation keeps keyboard remapping explicit and policy-gated:
 - Kinto remains an explicit compatibility lane for X11/xkeysnail-style workflows and is not auto-installed in the Wayland-first profile.
 - `check-keyboard-policy.sh` emits key=value status for CI and future doctor/status integration.
 
+## Dock/extension validation
+
+The dock and extension lane can be inspected without changing system state:
+
+```bash
+./profiles/linux-dev/workstation-v0/bin/check-gnome-dock-extension.sh
+```
+
+The helper emits key=value output for:
+
+- `gnome_extensions`
+- `gsettings`
+- `dash_to_dock`
+- `appindicator`
+- `favorite_apps_visibility`
+- `gnome_dock_extension_lane_ok`
+
+It is read-only and does not install, enable, or modify extensions.
+
 ## Follow-on work
 
 - Wayland-safe keyboard remap lane expansion


### PR DESCRIPTION
Closes #130.

What changed:
- Added `profiles/linux-dev/workstation-v0/bin/check-gnome-dock-extension.sh`.
- Added `.github/workflows/workstation-gnome-dock-validation.yml`.
- Documented the helper in `profiles/linux-dev/workstation-v0/gnome/README.md`.

Validation evidence:
- `bash -n profiles/linux-dev/workstation-v0/bin/check-gnome-dock-extension.sh`
- `bash profiles/linux-dev/workstation-v0/bin/check-gnome-dock-extension.sh`
- workflow smoke asserts required keys and a positive stubbed path

Known gaps:
- This helper is read-only and does not install or enable extensions.
- It does not alter the installed extension set.

Non-goals preserved:
- No package manifest changes.
- No GNOME Shell replacement.
- No runtime mutation.