### PR TITLE
repo hygiene: update agent instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,8 +1,10 @@
-Use the GitHub issue body as the source of truth.
+Use the GitHub issue body as the complete source of truth.
+
+Copilot is the primary executor for bounded issue-first PR work in this repository. The issue body must contain the full task, acceptance criteria, validation commands, and non-goals before assignment. Do not rely on later comments as required context.
 
 Before editing:
 
-1. Read the issue.
+1. Read the issue body.
 2. Inspect the repository.
 3. Identify existing validation commands.
 4. Keep the PR bounded to the issue scope.
@@ -16,6 +18,7 @@ When implementing:
 - Do not touch unrelated repositories.
 - Do not broaden scope without asking in the issue.
 - Do not claim production readiness unless the issue explicitly requests and acceptance criteria prove it.
+- Open one PR against the default branch unless the issue explicitly says otherwise.
 
 When opening the PR:
 
@@ -27,6 +30,12 @@ When opening the PR:
 - State non-goals preserved.
 - State anything blocked.
 - Do not mark ready if validation did not run.
+
+Delivery evidence:
+
+- A PR, branch, commit, or merge must exist in GitHub to count as delivery.
+- Comments, local task summaries, and draft notes are not delivery artifacts by themselves.
+- If blocked from creating a PR, report the blocker clearly on the issue.
 
 SourceOS-specific boundaries:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,11 +2,27 @@
 
 Work issue-first.
 
-Rules:
+## Dispatch policy
+
+Copilot is the primary executor for bounded issue-first PR work in this repository.
+
+Use Codex as a reviewer, cross-repo analyst, or backup implementation agent when Copilot is unavailable or when cross-repo reasoning is needed. Do not count Codex comments as delivery unless GitHub shows a PR, branch, commit, or merge.
+
+Delivery means one of the following exists in GitHub:
+
+- PR;
+- branch;
+- commit;
+- merge.
+
+Agent comments, summaries, and local-task reports are engagement signals only.
+
+## Rules
 
 - One repo, one issue, one PR.
 - Inspect the live repository before editing.
 - Use the GitHub issue body as the source of truth.
+- Put the full task, acceptance criteria, validation commands, and non-goals in the issue body before assignment.
 - Keep scope bounded to the issue body.
 - Do not broaden scope without asking in the issue.
 - Do not touch unrelated files.


### PR DESCRIPTION
Closes #137.

Updates `AGENTS.md` and `.github/copilot-instructions.md` to clarify issue-first bounded PR work, validation evidence requirements, and GitHub artifact requirements for delivery.

Validation:
- `test -s AGENTS.md`
- `test -s .github/copilot-instructions.md`
- `grep -F "Copilot" AGENTS.md`
- `grep -F "issue body" .github/copilot-instructions.md`
- `grep -F "PR, branch, commit, or merge" AGENTS.md`

Scope: docs/instructions only. No workflows, manifests, workstation implementation, or runtime behavior changed.