### PR TITLE
workstation-v0 aggregate polish doctor integration

### DIFF
--- a/.github/workflows/workstation-doctor-polish.yml
+++ b/.github/workflows/workstation-doctor-polish.yml
@@ -1,0 +1,98 @@
+name: workstation-doctor-polish
+
+on:
+  pull_request:
+    paths:
+      - 'profiles/linux-dev/workstation-v0/doctor.sh'
+      - 'profiles/linux-dev/workstation-v0/bin/check-workstation-polish.sh'
+      - '.github/workflows/workstation-doctor-polish.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'profiles/linux-dev/workstation-v0/doctor.sh'
+      - 'profiles/linux-dev/workstation-v0/bin/check-workstation-polish.sh'
+      - '.github/workflows/workstation-doctor-polish.yml'
+
+jobs:
+  doctor-polish-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Syntax check doctor
+        run: |
+          set -euo pipefail
+          bash -n profiles/linux-dev/workstation-v0/doctor.sh
+
+      - name: Smoke: doctor JSON shape survives valid aggregate polish
+        run: |
+          set -euo pipefail
+          doctor='profiles/linux-dev/workstation-v0/doctor.sh'
+          helper='profiles/linux-dev/workstation-v0/bin/check-workstation-polish.sh'
+          backup=$(mktemp)
+          cp "$helper" "$backup"
+          restore(){ cp "$backup" "$helper"; }
+          trap restore EXIT
+          cat > "$helper" <<'EOF'
+          #!/usr/bin/env bash
+          set -euo pipefail
+          printf 'mac_polish.helper=present\n'
+          printf 'keyboard_policy.helper=present\n'
+          printf 'keyboard_policy.policy_ok=yes\n'
+          EOF
+          chmod +x "$helper"
+
+          set +e
+          out=$(bash "$doctor" --json)
+          rc=$?
+          set -e
+          if [ "$rc" -ne 0 ] && [ "$rc" -ne 2 ]; then
+            echo "Unexpected exit code: $rc" >&2
+            exit 1
+          fi
+          python3 -c 'import json,sys
+j=json.loads(sys.stdin.read())
+assert j["kind"]=="sourceos.doctor"
+assert j["profile"]=="linux-dev/workstation-v0"
+assert set(j)>= {"kind","profile","ok","summary","results"}
+assert isinstance(j["results"], list)
+print("doctor-json-schema: ok")' <<<"$out"
+          grep -F '"name":"mac-polish-helper"' <<<"$out" >/dev/null
+          grep -F '"name":"keyboard-policy-helper"' <<<"$out" >/dev/null
+          grep -F '"name":"keyboard-policy"' <<<"$out" >/dev/null
+
+      - name: Smoke: invalid aggregate keyboard policy is warning-only
+        run: |
+          set -euo pipefail
+          doctor='profiles/linux-dev/workstation-v0/doctor.sh'
+          helper='profiles/linux-dev/workstation-v0/bin/check-workstation-polish.sh'
+          backup=$(mktemp)
+          cp "$helper" "$backup"
+          restore(){ cp "$backup" "$helper"; }
+          trap restore EXIT
+          cat > "$helper" <<'EOF'
+          #!/usr/bin/env bash
+          set -euo pipefail
+          printf 'mac_polish.helper=present\n'
+          printf 'keyboard_policy.helper=present\n'
+          printf 'keyboard_policy.policy_ok=no\n'
+          EOF
+          chmod +x "$helper"
+
+          set +e
+          out=$(bash "$doctor" --json)
+          rc=$?
+          set -e
+          if [ "$rc" -ne 0 ] && [ "$rc" -ne 2 ]; then
+            echo "Unexpected exit code: $rc" >&2
+            exit 1
+          fi
+          python3 -c 'import json,sys
+j=json.loads(sys.stdin.read())
+assert j["kind"]=="sourceos.doctor"
+assert j["profile"]=="linux-dev/workstation-v0"
+assert isinstance(j["results"], list)
+assert any(r.get("name")=="keyboard-policy" and r.get("level")=="warn" for r in j["results"])
+print("doctor-polish-warning: ok")' <<<"$out"

--- a/profiles/linux-dev/workstation-v0/doctor.sh
+++ b/profiles/linux-dev/workstation-v0/doctor.sh
@@ -304,6 +304,48 @@ check_lampstand_unit(){
   esac
 }
 
+check_workstation_polish(){
+  local helper="$(cd "$(dirname "$0")" && pwd)/bin/check-workstation-polish.sh"
+  local out policy_ok
+
+  if [[ ! -f "$helper" ]]; then
+    warn "workstation polish helper missing: $helper"
+    record_result warn workstation-polish-helper "missing"
+    return
+  fi
+
+  if ! out="$(bash "$helper" 2>/dev/null)"; then
+    warn "workstation polish helper failed"
+    record_result warn workstation-polish "helper failed"
+    return
+  fi
+
+  if grep -Fqx 'mac_polish.helper=present' <<<"$out"; then
+    info "ok: Mac polish helper signal"
+    record_result ok mac-polish-helper "present"
+  else
+    warn "Mac polish helper signal missing"
+    record_result warn mac-polish-helper "missing"
+  fi
+
+  if grep -Fqx 'keyboard_policy.helper=present' <<<"$out"; then
+    info "ok: keyboard policy helper signal"
+    record_result ok keyboard-policy-helper "present"
+  else
+    warn "keyboard policy helper signal missing"
+    record_result warn keyboard-policy-helper "missing"
+  fi
+
+  policy_ok="$(awk -F= '$1=="keyboard_policy.policy_ok" {print $2}' <<<"$out" | tail -n1)"
+  if [[ "$policy_ok" == "yes" ]]; then
+    info "ok: keyboard policy valid"
+    record_result ok keyboard-policy "valid"
+  else
+    warn "keyboard policy is not valid"
+    record_result warn keyboard-policy "invalid"
+  fi
+}
+
 check_gsettings_equals(){
   local schema=$1
   local key=$2
@@ -398,6 +440,7 @@ main(){
   check rsync
   check_lampstand_lane
   check_lampstand_unit
+  check_workstation_polish
 
   if gnome_detect; then
     record_result info gnome "detected"


### PR DESCRIPTION
Closes #120.

What changed:
- Integrated `check-workstation-polish.sh` into `profiles/linux-dev/workstation-v0/doctor.sh`.
- Added warning-oriented doctor results for Mac polish and keyboard policy aggregate signals.
- Added `workstation-doctor-polish` smoke workflow for doctor JSON shape and warning-only behavior.

Validation evidence:
- `bash -n profiles/linux-dev/workstation-v0/doctor.sh`
- `bash profiles/linux-dev/workstation-v0/doctor.sh --json`
- workflow smoke validates `kind`, `profile`, `summary`, and `results` shape
- workflow smoke validates invalid aggregate keyboard policy emits warning result without changing doctor JSON shape

Known gaps:
- This does not change `sourceos status`; that was handled separately.

Non-goals preserved:
- No Lampstand implementation changes.
- No package manifest changes.
- No GNOME appearance defaults changed.
- No keyboard/remap installer behavior changed.