### PR TITLE
build(source-os): make installed sourceos-office path-safe (current main)

### DIFF
--- a/build/office-suite/scripts/install_sourceos_office_shell_smoke.sh
+++ b/build/office-suite/scripts/install_sourceos_office_shell_smoke.sh
@@ -17,6 +17,8 @@ OPEN_BIN="$HOME/.local/bin/sourceos-office-open"
 SOURCEOS_OFFICE_BIN="$HOME/.local/bin/sourceos-office"
 CLOUD_BIN="$HOME/.local/bin/office_cloud_handoff.sh"
 MIME_FILE="$XDG_CONFIG_HOME/mimeapps.list"
+TEST_DOC="$TMPDIR/demo.txt"
+echo "SourceOS office shell smoke" > "$TEST_DOC"
 
 [[ -f "$DESKTOP_FILE" ]] || {
   echo "office shell installer smoke failed: missing desktop entry" >&2
@@ -43,10 +45,13 @@ MIME_FILE="$XDG_CONFIG_HOME/mimeapps.list"
   exit 1
 }
 
-OUT="$($SOURCEOS_OFFICE_BIN help)"
-[[ "$OUT" == *"usage: sourceos-office"* ]] || {
-  echo "office shell installer smoke failed: sourceos-office help mismatch" >&2
-  exit 1
-}
+OUT="$(SOURCEOS_OFFICE_MODE=cloud "$SOURCEOS_OFFICE_BIN" open "$TEST_DOC")"
+case "$OUT" in
+  http://*|https://*) ;;
+  *)
+    echo "office shell installer smoke failed: installed sourceos-office open path did not return URL" >&2
+    exit 1
+    ;;
+esac
 
 echo "office shell installer smoke passed"

--- a/build/office-suite/scripts/sourceos-office
+++ b/build/office-suite/scripts/sourceos-office
@@ -1,22 +1,37 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 CMD="${1:-help}"
 shift || true
 
+resolve_helper() {
+  local sibling="$1"
+  local repo_path="$2"
+  if [[ -x "$SCRIPT_DIR/$sibling" ]]; then
+    printf '%s\n' "$SCRIPT_DIR/$sibling"
+    return 0
+  fi
+  if [[ -x "$ROOT/$repo_path" ]]; then
+    printf '%s\n' "$ROOT/$repo_path"
+    return 0
+  fi
+  return 1
+}
+
 case "$CMD" in
   install)
-    "$ROOT/build/office-suite/scripts/install_sourceos_office_shell.sh"
+    "$(resolve_helper install_sourceos_office_shell.sh build/office-suite/scripts/install_sourceos_office_shell.sh)"
     ;;
   verify)
-    "$ROOT/build/office-suite/scripts/office_shell_verify.sh"
+    "$(resolve_helper office_shell_verify.sh build/office-suite/scripts/office_shell_verify.sh)"
     ;;
   open)
-    "$ROOT/build/office-suite/scripts/office_open.sh" "$@"
+    "$(resolve_helper office_open.sh build/office-suite/scripts/office_open.sh)" "$@"
     ;;
   search)
-    "$ROOT/build/office-suite/scripts/office_search_open.sh" "$@"
+    "$(resolve_helper office_search_open.sh build/office-suite/scripts/office_search_open.sh)" "$@"
     ;;
   help|*)
     cat <<'EOF'


### PR DESCRIPTION
## Summary

Fix the installed `sourceos-office` front door so it resolves sibling installed helpers first and only falls back to repo-relative helpers when run from the repo tree.

Files:
- `build/office-suite/scripts/sourceos-office`
- `build/office-suite/scripts/install_sourceos_office_shell_smoke.sh`

## Why

Current `main` stages `sourceos-office` into `~/.local/bin`, but the installed command still computes helper paths repo-relatively. That works in-repo and breaks when installed. This follow-on closes that installed-path bug and proves it by exercising an installed `open` path in cloud mode.
