### PR TITLE
build(source-os): make office-shell verify installed-mode safe

### DIFF
--- a/build/office-suite/scripts/install_sourceos_office_shell.sh
+++ b/build/office-suite/scripts/install_sourceos_office_shell.sh
@@ -9,11 +9,13 @@ BIN_DIR="$HOME/.local/bin"
 
 mkdir -p "$BIN_DIR"
 cp "$ROOT/build/office-suite/scripts/sourceos-office" "$BIN_DIR/sourceos-office"
-chmod +x "$BIN_DIR/sourceos-office"
+cp "$ROOT/build/office-suite/scripts/office_shell_verify.sh" "$BIN_DIR/office_shell_verify.sh"
+chmod +x "$BIN_DIR/sourceos-office" "$BIN_DIR/office_shell_verify.sh"
 
 if [[ -x "$ROOT/build/office-suite/scripts/verify_office_suite_profile.sh" ]]; then
   "$ROOT/build/office-suite/scripts/verify_office_suite_profile.sh"
 fi
 
 echo "installed sourceos-office to $BIN_DIR/sourceos-office"
+echo "installed office_shell_verify.sh to $BIN_DIR/office_shell_verify.sh"
 echo "SourceOS office shell install completed"

--- a/build/office-suite/scripts/install_sourceos_office_shell_smoke.sh
+++ b/build/office-suite/scripts/install_sourceos_office_shell_smoke.sh
@@ -15,6 +15,7 @@ mkdir -p "$HOME"
 DESKTOP_FILE="$XDG_DATA_HOME/applications/sourceos-office.desktop"
 OPEN_BIN="$HOME/.local/bin/sourceos-office-open"
 SOURCEOS_OFFICE_BIN="$HOME/.local/bin/sourceos-office"
+VERIFY_BIN="$HOME/.local/bin/office_shell_verify.sh"
 CLOUD_BIN="$HOME/.local/bin/office_cloud_handoff.sh"
 MIME_FILE="$XDG_CONFIG_HOME/mimeapps.list"
 TEST_DOC="$TMPDIR/demo.txt"
@@ -32,6 +33,11 @@ echo "SourceOS office shell smoke" > "$TEST_DOC"
 
 [[ -x "$SOURCEOS_OFFICE_BIN" ]] || {
   echo "office shell installer smoke failed: missing sourceos-office command" >&2
+  exit 1
+}
+
+[[ -x "$VERIFY_BIN" ]] || {
+  echo "office shell installer smoke failed: missing office_shell_verify helper" >&2
   exit 1
 }
 
@@ -53,5 +59,11 @@ case "$OUT" in
     exit 1
     ;;
 esac
+
+VERIFY_OUT="$($SOURCEOS_OFFICE_BIN verify)"
+[[ "$VERIFY_OUT" == *"office shell verification passed"* ]] || {
+  echo "office shell installer smoke failed: installed verify path did not pass" >&2
+  exit 1
+}
 
 echo "office shell installer smoke passed"

--- a/build/office-suite/scripts/office_shell_verify.sh
+++ b/build/office-suite/scripts/office_shell_verify.sh
@@ -1,7 +1,66 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+APP_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/applications"
+CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}"
+DESKTOP_FILE="$APP_DIR/sourceos-office.desktop"
+MIME_FILE="$CONFIG_DIR/mimeapps.list"
+
+if [[ -x "$SCRIPT_DIR/sourceos-office-open" ]]; then
+  [[ -f "$DESKTOP_FILE" ]] || {
+    echo "office shell verification failed: missing desktop entry" >&2
+    exit 1
+  }
+
+  [[ -x "$SCRIPT_DIR/sourceos-office" ]] || {
+    echo "office shell verification failed: missing sourceos-office command" >&2
+    exit 1
+  }
+
+  [[ -x "$SCRIPT_DIR/sourceos-office-open" ]] || {
+    echo "office shell verification failed: missing sourceos-office-open helper" >&2
+    exit 1
+  }
+
+  [[ -x "$SCRIPT_DIR/office_cloud_handoff.sh" ]] || {
+    echo "office shell verification failed: missing cloud handoff helper" >&2
+    exit 1
+  }
+
+  [[ -x "$SCRIPT_DIR/office_search_handoff.sh" ]] || {
+    echo "office shell verification failed: missing search handoff helper" >&2
+    exit 1
+  }
+
+  [[ -x "$SCRIPT_DIR/office_search_open.sh" ]] || {
+    echo "office shell verification failed: missing search open helper" >&2
+    exit 1
+  }
+
+  [[ -f "$MIME_FILE" ]] || {
+    echo "office shell verification failed: missing MIME defaults" >&2
+    exit 1
+  }
+
+  TMPDIR="$(mktemp -d)"
+  trap 'rm -rf "$TMPDIR"' EXIT
+  TEST_DOC="$TMPDIR/verify.txt"
+  echo "SourceOS office verify" > "$TEST_DOC"
+
+  OUT="$(SOURCEOS_OFFICE_MODE=cloud "$SCRIPT_DIR/sourceos-office" open "$TEST_DOC")"
+  case "$OUT" in
+    http://*|https://*) ;;
+    *)
+      echo "office shell verification failed: installed open path did not return URL" >&2
+      exit 1
+      ;;
+  esac
+
+  echo "office shell verification passed"
+  exit 0
+fi
 
 "$ROOT/build/office-suite/scripts/verify_office_desktop_entry.sh"
 


### PR DESCRIPTION
## Summary

Add the next installed-mode office-shell slice on top of current `main`.

Files:
- `build/office-suite/scripts/office_shell_verify.sh`
- `build/office-suite/scripts/install_sourceos_office_shell.sh`
- `build/office-suite/scripts/install_sourceos_office_shell_smoke.sh`

## Why

The installed `sourceos-office` front door is now path-safe, but the installed `verify` path still was not. This follow-on stages the verify helper, makes it installation-aware, and proves the installed verify flow works.
