### PR TITLE
build(source-os): make installed sourceos-office install path work

### DIFF
--- a/build/office-suite/scripts/install_sourceos_office_shell.sh
+++ b/build/office-suite/scripts/install_sourceos_office_shell.sh
@@ -9,13 +9,15 @@ BIN_DIR="$HOME/.local/bin"
 
 mkdir -p "$BIN_DIR"
 cp "$ROOT/build/office-suite/scripts/sourceos-office" "$BIN_DIR/sourceos-office"
+cp "$ROOT/build/office-suite/scripts/install_sourceos_office_shell.sh" "$BIN_DIR/install_sourceos_office_shell.sh"
 cp "$ROOT/build/office-suite/scripts/office_shell_verify.sh" "$BIN_DIR/office_shell_verify.sh"
-chmod +x "$BIN_DIR/sourceos-office" "$BIN_DIR/office_shell_verify.sh"
+chmod +x "$BIN_DIR/sourceos-office" "$BIN_DIR/install_sourceos_office_shell.sh" "$BIN_DIR/office_shell_verify.sh"
 
 if [[ -x "$ROOT/build/office-suite/scripts/verify_office_suite_profile.sh" ]]; then
   "$ROOT/build/office-suite/scripts/verify_office_suite_profile.sh"
 fi
 
 echo "installed sourceos-office to $BIN_DIR/sourceos-office"
+echo "installed install_sourceos_office_shell.sh to $BIN_DIR/install_sourceos_office_shell.sh"
 echo "installed office_shell_verify.sh to $BIN_DIR/office_shell_verify.sh"
 echo "SourceOS office shell install completed"

--- a/build/office-suite/scripts/install_sourceos_office_shell_smoke.sh
+++ b/build/office-suite/scripts/install_sourceos_office_shell_smoke.sh
@@ -15,6 +15,7 @@ mkdir -p "$HOME"
 DESKTOP_FILE="$XDG_DATA_HOME/applications/sourceos-office.desktop"
 OPEN_BIN="$HOME/.local/bin/sourceos-office-open"
 SOURCEOS_OFFICE_BIN="$HOME/.local/bin/sourceos-office"
+INSTALL_BIN="$HOME/.local/bin/install_sourceos_office_shell.sh"
 VERIFY_BIN="$HOME/.local/bin/office_shell_verify.sh"
 CLOUD_BIN="$HOME/.local/bin/office_cloud_handoff.sh"
 MIME_FILE="$XDG_CONFIG_HOME/mimeapps.list"
@@ -33,6 +34,11 @@ echo "SourceOS office shell smoke" > "$TEST_DOC"
 
 [[ -x "$SOURCEOS_OFFICE_BIN" ]] || {
   echo "office shell installer smoke failed: missing sourceos-office command" >&2
+  exit 1
+}
+
+[[ -x "$INSTALL_BIN" ]] || {
+  echo "office shell installer smoke failed: missing install_sourceos_office_shell helper" >&2
   exit 1
 }
 
@@ -83,5 +89,7 @@ case "$SEARCH_OUT" in
     exit 1
     ;;
 esac
+
+"$SOURCEOS_OFFICE_BIN" install >/dev/null
 
 echo "office shell installer smoke passed"


### PR DESCRIPTION
## Summary

Fix the installed `sourceos-office install` path so it works in installed mode.

Files:
- `build/office-suite/scripts/install_sourceos_office_shell.sh`
- `build/office-suite/scripts/install_sourceos_office_shell_smoke.sh`

## Why

The installed front door already proves `open`, `verify`, and `search`. This follow-on stages the install helper itself and proves the installed `install` command works too.
