### PR TITLE
build(source-os): add writer-first sourceos-office new workflow

### DIFF
--- a/build/office-suite/scripts/install_sourceos_office_shell.sh
+++ b/build/office-suite/scripts/install_sourceos_office_shell.sh
@@ -11,7 +11,9 @@ mkdir -p "$BIN_DIR"
 cp "$ROOT/build/office-suite/scripts/sourceos-office" "$BIN_DIR/sourceos-office"
 cp "$ROOT/build/office-suite/scripts/install_sourceos_office_shell.sh" "$BIN_DIR/install_sourceos_office_shell.sh"
 cp "$ROOT/build/office-suite/scripts/office_shell_verify.sh" "$BIN_DIR/office_shell_verify.sh"
-chmod +x "$BIN_DIR/sourceos-office" "$BIN_DIR/install_sourceos_office_shell.sh" "$BIN_DIR/office_shell_verify.sh"
+cp "$ROOT/build/office-suite/scripts/office_new.sh" "$BIN_DIR/office_new.sh"
+cp "$ROOT/build/office-suite/templates/sovereign/sourceos-default-writer.fodt" "$BIN_DIR/sourceos-default-writer.fodt"
+chmod +x "$BIN_DIR/sourceos-office" "$BIN_DIR/install_sourceos_office_shell.sh" "$BIN_DIR/office_shell_verify.sh" "$BIN_DIR/office_new.sh"
 
 if [[ -x "$ROOT/build/office-suite/scripts/verify_office_suite_profile.sh" ]]; then
   "$ROOT/build/office-suite/scripts/verify_office_suite_profile.sh"
@@ -20,4 +22,6 @@ fi
 echo "installed sourceos-office to $BIN_DIR/sourceos-office"
 echo "installed install_sourceos_office_shell.sh to $BIN_DIR/install_sourceos_office_shell.sh"
 echo "installed office_shell_verify.sh to $BIN_DIR/office_shell_verify.sh"
+echo "installed office_new.sh to $BIN_DIR/office_new.sh"
+echo "installed sourceos-default-writer.fodt to $BIN_DIR/sourceos-default-writer.fodt"
 echo "SourceOS office shell install completed"

--- a/build/office-suite/scripts/install_sourceos_office_shell_smoke.sh
+++ b/build/office-suite/scripts/install_sourceos_office_shell_smoke.sh
@@ -17,9 +17,11 @@ OPEN_BIN="$HOME/.local/bin/sourceos-office-open"
 SOURCEOS_OFFICE_BIN="$HOME/.local/bin/sourceos-office"
 INSTALL_BIN="$HOME/.local/bin/install_sourceos_office_shell.sh"
 VERIFY_BIN="$HOME/.local/bin/office_shell_verify.sh"
+NEW_BIN="$HOME/.local/bin/office_new.sh"
 CLOUD_BIN="$HOME/.local/bin/office_cloud_handoff.sh"
 MIME_FILE="$XDG_CONFIG_HOME/mimeapps.list"
 TEST_DOC="$TMPDIR/demo.txt"
+NEW_DOC="$TMPDIR/new-writer.fodt"
 echo "SourceOS office shell smoke" > "$TEST_DOC"
 
 [[ -f "$DESKTOP_FILE" ]] || {
@@ -44,6 +46,11 @@ echo "SourceOS office shell smoke" > "$TEST_DOC"
 
 [[ -x "$VERIFY_BIN" ]] || {
   echo "office shell installer smoke failed: missing office_shell_verify helper" >&2
+  exit 1
+}
+
+[[ -x "$NEW_BIN" ]] || {
+  echo "office shell installer smoke failed: missing office_new helper" >&2
   exit 1
 }
 
@@ -89,6 +96,21 @@ case "$SEARCH_OUT" in
     exit 1
     ;;
 esac
+
+NEW_OUT="$($SOURCEOS_OFFICE_BIN new writer "$NEW_DOC")"
+[[ "$NEW_OUT" == "$NEW_DOC" ]] || {
+  echo "office shell installer smoke failed: installed sourceos-office new path did not return created file" >&2
+  exit 1
+}
+[[ -f "$NEW_DOC" ]] || {
+  echo "office shell installer smoke failed: installed sourceos-office new path did not create file" >&2
+  exit 1
+}
+
+grep -q "SourceOS sovereign writer template placeholder" "$NEW_DOC" || {
+  echo "office shell installer smoke failed: created writer file does not contain template payload" >&2
+  exit 1
+}
 
 "$SOURCEOS_OFFICE_BIN" install >/dev/null
 

--- a/build/office-suite/scripts/office_new.sh
+++ b/build/office-suite/scripts/office_new.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+  echo "usage: $0 <writer> <output-file>" >&2
+  exit 1
+fi
+
+KIND="$1"
+OUTPUT="$2"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+case "$KIND" in
+  writer)
+    if [[ -f "$SCRIPT_DIR/sourceos-default-writer.fodt" ]]; then
+      TEMPLATE="$SCRIPT_DIR/sourceos-default-writer.fodt"
+    else
+      TEMPLATE="$ROOT/build/office-suite/templates/sovereign/sourceos-default-writer.fodt"
+    fi
+    ;;
+  *)
+    echo "unsupported office kind: $KIND" >&2
+    exit 2
+    ;;
+esac
+
+mkdir -p "$(dirname "$OUTPUT")"
+cp "$TEMPLATE" "$OUTPUT"
+echo "$OUTPUT"

--- a/build/office-suite/scripts/sourceos-office
+++ b/build/office-suite/scripts/sourceos-office
@@ -33,9 +33,12 @@ case "$CMD" in
   search)
     "$(resolve_helper office_search_open.sh build/office-suite/scripts/office_search_open.sh)" "$@"
     ;;
+  new)
+    "$(resolve_helper office_new.sh build/office-suite/scripts/office_new.sh)" "$@"
+    ;;
   help|*)
     cat <<'EOF'
-usage: sourceos-office <install|verify|open|search> [args]
+usage: sourceos-office <install|verify|open|search|new> [args]
 EOF
     ;;
 esac


### PR DESCRIPTION
## Summary

Add the first bounded `sourceos-office new` workflow on top of current `main`.

Files:
- `build/office-suite/scripts/office_new.sh`
- `build/office-suite/scripts/sourceos-office`
- `build/office-suite/scripts/install_sourceos_office_shell.sh`
- `build/office-suite/scripts/install_sourceos_office_shell_smoke.sh`

## Why

Current `main` has a credible installed front door for `open`, `verify`, `search`, and `install`. This follow-on adds the first real create-from-template workflow in installed mode, bounded honestly to the existing sovereign Writer template.
