### PR TITLE
build(source-os): add default path for writer-first new workflow

### DIFF
--- a/build/office-suite/scripts/install_sourceos_office_shell_smoke.sh
+++ b/build/office-suite/scripts/install_sourceos_office_shell_smoke.sh
@@ -112,6 +112,24 @@ grep -q "SourceOS sovereign writer template placeholder" "$NEW_DOC" || {
   exit 1
 }
 
+DEFAULT_NEW_OUT="$($SOURCEOS_OFFICE_BIN new writer)"
+case "$DEFAULT_NEW_OUT" in
+  "$HOME"/Documents/SourceOS/agent-output/*.fodt) ;;
+  *)
+    echo "office shell installer smoke failed: default new path did not use SourceOS agent-output" >&2
+    exit 1
+    ;;
+esac
+[[ -f "$DEFAULT_NEW_OUT" ]] || {
+  echo "office shell installer smoke failed: default new path did not create file" >&2
+  exit 1
+}
+
+grep -q "SourceOS sovereign writer template placeholder" "$DEFAULT_NEW_OUT" || {
+  echo "office shell installer smoke failed: default writer file does not contain template payload" >&2
+  exit 1
+}
+
 "$SOURCEOS_OFFICE_BIN" install >/dev/null
 
 echo "office shell installer smoke passed"

--- a/build/office-suite/scripts/office_new.sh
+++ b/build/office-suite/scripts/office_new.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [[ $# -lt 2 ]]; then
-  echo "usage: $0 <writer> <output-file>" >&2
+if [[ $# -lt 1 ]]; then
+  echo "usage: $0 <writer> [output-file]" >&2
   exit 1
 fi
 
 KIND="$1"
-OUTPUT="$2"
+OUTPUT="${2:-}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 
@@ -18,12 +18,19 @@ case "$KIND" in
     else
       TEMPLATE="$ROOT/build/office-suite/templates/sovereign/sourceos-default-writer.fodt"
     fi
+    SUFFIX="fodt"
     ;;
   *)
     echo "unsupported office kind: $KIND" >&2
     exit 2
     ;;
 esac
+
+if [[ -z "$OUTPUT" ]]; then
+  OUTPUT_DIR="$HOME/Documents/SourceOS/agent-output"
+  mkdir -p "$OUTPUT_DIR"
+  OUTPUT="$OUTPUT_DIR/sourceos-${KIND}-$(date +%Y%m%d-%H%M%S).${SUFFIX}"
+fi
 
 mkdir -p "$(dirname "$OUTPUT")"
 cp "$TEMPLATE" "$OUTPUT"


### PR DESCRIPTION
## Summary

Improve the bounded `sourceos-office new writer` workflow on top of current `main`.

Files:
- `build/office-suite/scripts/office_new.sh`
- `build/office-suite/scripts/install_sourceos_office_shell_smoke.sh`

## Why

The Writer-first `new` workflow is already on `main`, but it still required a full manual output path every time. This follow-on adds a sane default output location in `~/Documents/SourceOS/agent-output` and proves that installed-mode default behavior works.
