### PR TITLE
workstation-v0 mac defaults validation helper

### DIFF
--- a/.github/workflows/workstation-mac-defaults.yml
+++ b/.github/workflows/workstation-mac-defaults.yml
@@ -1,0 +1,49 @@
+name: workstation-mac-defaults
+
+on:
+  pull_request:
+    paths:
+      - 'profiles/linux-dev/workstation-v0/gnome/mac-defaults.sh'
+      - 'profiles/linux-dev/workstation-v0/bin/check-mac-defaults.sh'
+      - 'profiles/linux-dev/workstation-v0/gnome/README.md'
+      - '.github/workflows/workstation-mac-defaults.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'profiles/linux-dev/workstation-v0/gnome/mac-defaults.sh'
+      - 'profiles/linux-dev/workstation-v0/bin/check-mac-defaults.sh'
+      - 'profiles/linux-dev/workstation-v0/gnome/README.md'
+      - '.github/workflows/workstation-mac-defaults.yml'
+
+jobs:
+  mac-defaults-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Syntax check mac defaults scripts
+        run: |
+          set -euo pipefail
+          bash -n profiles/linux-dev/workstation-v0/gnome/mac-defaults.sh
+          bash -n profiles/linux-dev/workstation-v0/bin/check-mac-defaults.sh
+
+      - name: Smoke: mac defaults helper reports expected behavior slice
+        run: |
+          set -euo pipefail
+          helper='profiles/linux-dev/workstation-v0/bin/check-mac-defaults.sh'
+          out=$(bash "$helper")
+          grep -F 'mac_defaults_script=present' <<<"$out" >/dev/null
+          grep -F 'hot_corners_disabled=present' <<<"$out" >/dev/null
+          grep -F 'clock_12h=present' <<<"$out" >/dev/null
+          grep -F 'locate_pointer=present' <<<"$out" >/dev/null
+          grep -F 'nautilus_double_click=present' <<<"$out" >/dev/null
+          grep -F 'dock_favorites_seed=present' <<<"$out" >/dev/null
+          grep -F 'files_binding=present' <<<"$out" >/dev/null
+          grep -F 'terminal_binding=present' <<<"$out" >/dev/null
+          grep -F 'screenshot_screen_binding=present' <<<"$out" >/dev/null
+          grep -F 'screenshot_area_binding=present' <<<"$out" >/dev/null
+          grep -F 'screenshot_ui_binding=present' <<<"$out" >/dev/null
+          grep -F 'screenshot_folder_binding=present' <<<"$out" >/dev/null
+          grep -F 'screenshot_directory=present' <<<"$out" >/dev/null

--- a/profiles/linux-dev/workstation-v0/bin/check-mac-defaults.sh
+++ b/profiles/linux-dev/workstation-v0/bin/check-mac-defaults.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Validate the workstation-v0 GNOME mac-defaults script without running GNOME.
+# Emits key=value lines for CI/reviewer consumption.
+
+profile_dir(){
+  cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd
+}
+
+present(){
+  local key=$1
+  local pattern=$2
+  local file=$3
+  if grep -Fq "$pattern" "$file" 2>/dev/null; then
+    printf '%s=present\n' "$key"
+  else
+    printf '%s=missing\n' "$key"
+  fi
+}
+
+main(){
+  local pdir script
+  pdir="$(profile_dir)"
+  script="$pdir/gnome/mac-defaults.sh"
+
+  if [[ -s "$script" ]]; then
+    printf 'mac_defaults_script=present\n'
+  else
+    printf 'mac_defaults_script=missing\n'
+    exit 0
+  fi
+
+  present hot_corners_disabled "enable-hot-corners false" "$script"
+  present clock_12h "clock-format '12h'" "$script"
+  present locate_pointer "locate-pointer true" "$script"
+  present nautilus_double_click "org.gnome.nautilus.preferences click-policy 'double'" "$script"
+  present dock_favorites_seed "org.gnome.shell favorite-apps" "$script"
+  present files_binding "<Super>e" "$script"
+  present terminal_binding "<Super>Return" "$script"
+  present screenshot_screen_binding "<Super><Shift>3" "$script"
+  present screenshot_area_binding "<Super><Shift>4" "$script"
+  present screenshot_ui_binding "<Super><Shift>5" "$script"
+  present screenshot_folder_binding "<Super><Shift>6" "$script"
+  present screenshot_directory 'Pictures/Screenshots' "$script"
+}
+
+main "$@"

--- a/profiles/linux-dev/workstation-v0/gnome/README.md
+++ b/profiles/linux-dev/workstation-v0/gnome/README.md
@@ -42,6 +42,18 @@ Principles:
 - `Super+Shift+5` interactive screenshot UI
 - `Super+Shift+6` open screenshot directory
 
+## Mac defaults validation
+
+The mac-like GNOME defaults script can be inspected without running GNOME:
+
+```bash
+./profiles/linux-dev/workstation-v0/bin/check-mac-defaults.sh
+```
+
+The helper emits key=value output for the expected behavior slice, including hot corners, 12h clock, locate pointer, Nautilus click policy, dock favorites, Files/Terminal bindings, screenshot bindings, and screenshot directory setup.
+
+It is read-only and does not change active keybindings or GNOME settings.
+
 ## Appearance/sidebar polish v1
 
 This lane adds bounded visual/workflow polish without replacing GNOME Shell or libadwaita:


### PR DESCRIPTION
Closes #102.

What changed:
- Added `profiles/linux-dev/workstation-v0/bin/check-mac-defaults.sh`.
- Added `.github/workflows/workstation-mac-defaults.yml`.
- Documented the read-only validation hook in `profiles/linux-dev/workstation-v0/gnome/README.md`.

Validation evidence:
- `bash -n profiles/linux-dev/workstation-v0/gnome/mac-defaults.sh`
- `bash -n profiles/linux-dev/workstation-v0/bin/check-mac-defaults.sh`
- `bash profiles/linux-dev/workstation-v0/bin/check-mac-defaults.sh`
- workflow smoke asserts the expected hot-corner, clock, pointer, Nautilus, dock favorites, Files/Terminal, screenshot, and screenshot-directory markers.

Known gaps:
- This validates the script contents without running GNOME.

Non-goals preserved:
- No active keybindings changed.
- No GNOME defaults behavior changed.
- No package manifests changed.
- No `sourceos` or `doctor.sh` changes.