### PR TITLE
feat(spec): add .sourceos/manifest.json

### DIFF
--- a/.sourceos/manifest.json
+++ b/.sourceos/manifest.json
@@ -1,0 +1,23 @@
+{
+  "repo": "SociOS-Linux/source-os",
+  "domain": "image-build",
+  "specVersion": "0.1.0",
+  "ownedSchemas": [],
+  "syncEngines": [],
+  "sourceChannels": [],
+  "policyClasses": [
+    "critical"
+  ],
+  "auditEvents": [
+    "image.build.started",
+    "image.build.completed",
+    "image.build.failed",
+    "image.nix.eval"
+  ],
+  "dangerousSurfaces": [
+    "image.efi_vars_mutable",
+    "image.hardware_config.committed",
+    "image.substitute_trusted_override"
+  ],
+  "notes": "NixOS flake for SourceOS builder images. Phase 0: Apple Silicon (Asahi Linux) via M2 MacBook. hardware-configuration.nix is device-specific and must be generated on-device with nixos-generate-config."
+}


### PR DESCRIPTION
## Summary

- Adds `.sourceos/manifest.json`: domain `image-build`, policyClass `critical`.
- Documents dangerous surfaces: `image.efi_vars_mutable`, `image.hardware_config.committed`, `image.substitute_trusted_override`.
- Notes Phase 0 Apple Silicon target and `nixos-generate-config` on-device requirement.

## Test plan

- [ ] `nix flake check` on the feature branch
- [ ] Builder machine: `nixos-rebuild switch --flake .#builder-aarch64` succeeds