### PR TITLE
feat(secrets): sops-nix, credential wiring fix, signingPublicKey option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+
+# SOPS plaintext secrets — never commit
+hosts/**/secrets.yaml

--- a/flake.nix
+++ b/flake.nix
@@ -7,13 +7,17 @@
       url = "github:tpwrules/nixos-apple-silicon";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    sops-nix = {
+      url = "github:Mic92/sops-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
     lampstand-src = {
       url = "github:SocioProphet/lampstand";
       flake = false;
     };
   };
 
-  outputs = { self, nixpkgs, nixos-apple-silicon, lampstand-src }:
+  outputs = { self, nixpkgs, nixos-apple-silicon, sops-nix, lampstand-src }:
     let
       lib = nixpkgs.lib;
       systems = [ "x86_64-linux" "aarch64-linux" ];
@@ -85,6 +89,7 @@
           specialArgs = { inherit self; };
           modules = [
             nixos-apple-silicon.nixosModules.apple-silicon-support
+            sops-nix.nixosModules.sops
             self.nixosModules.sourceos-syncd
             ./hosts/builder-aarch64/default.nix
           ];

--- a/hosts/builder-aarch64/default.nix
+++ b/hosts/builder-aarch64/default.nix
@@ -1,4 +1,4 @@
-{ config, lib, pkgs, ... }:
+{ config, lib, pkgs, self, ... }:
 {
   imports = [
     ../../profiles/linux-dev/default.nix
@@ -51,25 +51,41 @@
 
   security.sudo.wheelNeedsPassword = false;
 
-  # sourceos-syncd daemon: polls local Katello (127.0.0.1:8443) every 5 min
-  # and applies new content view versions automatically.
-  # katelloPassword is loaded from the SOPS-managed secrets file at runtime;
-  # set sourceos.syncd.katelloPasswordFile before activating.
+  # ── SOPS secrets ────────────────────────────────────────────────────────────
+  # secrets.yaml is encrypted with the device age key generated at enrollment.
+  # Encrypt with: sops --encrypt --age $(cat /etc/sourceos/age.pub) secrets.yaml
+  # The plaintext file is never committed to the repo.
+  sops.defaultSopsFile = ./secrets.yaml;
+  sops.age.keyFile = "/etc/sourceos/age.key";
+  sops.secrets.katello-password = {
+    owner = "sourceos-syncd";
+    group = "sourceos-syncd";
+    mode = "0400";
+  };
+
+  # ── sourceos-syncd daemon ────────────────────────────────────────────────────
+  # Polls local Katello every 5 min; applies new stable content view versions.
+  # Password loaded via SOPS-managed secret (not committed to repo).
   sourceos.syncd = {
     enable = true;
+    # package and sourceosBoot.package must point to built derivations.
+    # These are set below as overrides once the package derivations exist.
+    # For now, use placeholder that will be replaced with the real package.
     katelloUrl = "https://127.0.0.1:8443";
     lifecycleEnv = "stable";
     locus = "local";
     flakeRef = "github:SociOS-Linux/source-os#builder-aarch64";
     pollInterval = 300;
-    noVerifySsl = true;  # local self-signed cert; disable when real cert is provisioned
+    noVerifySsl = true;
+    katelloPasswordFile = config.sops.secrets.katello-password.path;
+    # signingPublicKey: set after generating the minisign key pair.
+    # Generate: minisign -G -p /etc/sourceos/nix-cache.pub -s /run/secrets/nix-cache.key
+    # Then embed the public key string here.
     healthCheck = {
       enable = true;
       delayAfterBootSec = 120;
       rollbackOnFailure = true;
     };
-    # katelloPasswordFile = "/run/secrets/katello-password";
-    # Set katelloPasswordFile (via sops-nix) before first activation.
   };
 
   system.stateVersion = "25.05";

--- a/hosts/builder-aarch64/secrets.yaml.example
+++ b/hosts/builder-aarch64/secrets.yaml.example
@@ -1,0 +1,6 @@
+# secrets.yaml.example — copy to secrets.yaml and encrypt before committing.
+# Encrypt: sops --encrypt --age $(cat /etc/sourceos/age.pub) secrets.yaml > secrets.yaml.enc
+# Never commit the plaintext secrets.yaml.
+#
+# Required secrets for builder-aarch64:
+katello-password: "REPLACE_WITH_KATELLO_ADMIN_PASSWORD"

--- a/modules/nixos/sourceos-syncd/default.nix
+++ b/modules/nixos/sourceos-syncd/default.nix
@@ -1,20 +1,8 @@
 { config, lib, pkgs, ... }:
 let
   cfg = config.sourceos.syncd;
-
-  # sourceos-syncd is installed as a Python package on the device.
-  # The package derivation lives in packages/sourceos-syncd.nix; this module
-  # just wires it into systemd. If the package is not yet in the flake's
-  # packages output, set cfg.package to pkgs.sourceos-syncd once it's built.
-  defaultPackage = cfg.package;
-
-  syncEnv = lib.optionalAttrs (cfg.katelloPassword != "") {
-    KATELLO_PASSWORD = cfg.katelloPassword;
-  } // lib.optionalAttrs (cfg.katelloPasswordFile != "") {
-    # prefer the secrets file over inline value
-  };
-
-  credentialFile = lib.mkIf (cfg.katelloPasswordFile != "") cfg.katelloPasswordFile;
+  syncdPkg = cfg.package;
+  bootPkg = cfg.sourceosBoot.package;
 
 in
 {
@@ -98,6 +86,23 @@ in
       description = "Skip TLS certificate verification (local dev only).";
     };
 
+    signingPublicKey = lib.mkOption {
+      type = lib.types.str;
+      default = "";
+      description = ''
+        minisign public key (RWS...) embedded in the image. When set, the
+        daemon verifies the nix-cache-info signature before running nix copy.
+        Generate with: minisign -G -p /etc/sourceos/nix-cache.pub -s /run/secrets/nix-cache.key
+      '';
+    };
+
+    sourceosBoot = {
+      package = lib.mkOption {
+        type = lib.types.package;
+        description = "The sourceos-boot package for rollback execution.";
+      };
+    };
+
     # Health check options
 
     healthCheck = {
@@ -148,31 +153,37 @@ in
         Restart = "on-failure";
         RestartSec = "30s";
 
+        # LoadCredential places the secret at /run/credentials/<service>/<name>.
+        # The daemon reads KATELLO_PASSWORD_FILE (supported since feat/content-signing)
+        # so we point that env var at the credential path. This avoids putting
+        # the plaintext password in the process environment.
+        LoadCredential = lib.optional (cfg.katelloPasswordFile != "")
+          "KATELLO_PASSWORD_SECRET:${cfg.katelloPasswordFile}";
+
+        Environment =
+          lib.optional (cfg.katelloPassword != "") "KATELLO_PASSWORD=${cfg.katelloPassword}"
+          ++ lib.optional (cfg.katelloPasswordFile != "")
+               "KATELLO_PASSWORD_FILE=/run/credentials/sourceos-syncd.service/KATELLO_PASSWORD_SECRET"
+          ++ lib.optional (cfg.signingPublicKey != "")
+               "SOURCEOS_SIGNING_PUBLIC_KEY=${cfg.signingPublicKey}";
+
+        # Password is not passed as a CLI flag — it comes from KATELLO_PASSWORD
+        # or KATELLO_PASSWORD_FILE env (set above). All other config is explicit.
         ExecStart = lib.concatStringsSep " " (
-          [ "${defaultPackage}/bin/sourceos-syncd" "sync" "daemon" ]
-          ++ [ "--katello-url" cfg.katelloUrl ]
-          ++ [ "--katello-user" cfg.katelloUser ]
-          ++ [ "--org" cfg.org ]
-          ++ [ "--content-view" cfg.contentView ]
+          [ "${syncdPkg}/bin/sourceos-syncd" "sync" "daemon" ]
+          ++ [ "--katello-url" (lib.escapeShellArg cfg.katelloUrl) ]
+          ++ [ "--katello-user" (lib.escapeShellArg cfg.katelloUser) ]
+          ++ [ "--org" (lib.escapeShellArg cfg.org) ]
+          ++ [ "--content-view" (lib.escapeShellArg cfg.contentView) ]
           ++ [ "--lifecycle-env" cfg.lifecycleEnv ]
           ++ [ "--locus" cfg.locus ]
-          ++ [ "--flake-ref" cfg.flakeRef ]
+          ++ [ "--flake-ref" (lib.escapeShellArg cfg.flakeRef) ]
           ++ [ "--poll-interval" (toString cfg.pollInterval) ]
-          ++ [ "--store-root" cfg.storeRoot ]
+          ++ [ "--store-root" (lib.escapeShellArg cfg.storeRoot) ]
           ++ lib.optional cfg.noVerifySsl "--no-verify-ssl"
+          ++ lib.optional (cfg.signingPublicKey != "")
+               "--signing-public-key ${lib.escapeShellArg cfg.signingPublicKey}"
         );
-
-        Environment = lib.mapAttrsToList (k: v: "${k}=${v}") (
-          lib.optionalAttrs (cfg.katelloPassword != "") {
-            KATELLO_PASSWORD = cfg.katelloPassword;
-          }
-        );
-
-        LoadCredential = lib.optional (cfg.katelloPasswordFile != "")
-          "KATELLO_PASSWORD:${cfg.katelloPasswordFile}";
-
-        EnvironmentFiles = lib.optional (cfg.katelloPasswordFile != "")
-          "/run/credentials/sourceos-syncd.service/KATELLO_PASSWORD";
       };
     };
 
@@ -189,16 +200,17 @@ in
 
         ExecStart = pkgs.writeShellScript "sourceos-health-check" ''
           set -euo pipefail
-          ${defaultPackage}/bin/sourceos-syncd sync check-health \
-            --store-root ${lib.escapeShellArg cfg.storeRoot} \
-            --katello-url ${lib.escapeShellArg cfg.katelloUrl} \
-            ${lib.optionalString cfg.noVerifySsl "--no-verify-ssl"} \
-            && exit 0
+          if ${syncdPkg}/bin/sourceos-syncd sync check-health \
+              --store-root ${lib.escapeShellArg cfg.storeRoot} \
+              --katello-url ${lib.escapeShellArg cfg.katelloUrl} \
+              ${lib.optionalString cfg.noVerifySsl "--no-verify-ssl"}; then
+            exit 0
+          fi
 
           echo "sourceos-health-check: UNHEALTHY" >&2
           ${lib.optionalString cfg.healthCheck.rollbackOnFailure ''
             echo "sourceos-health-check: triggering rollback" >&2
-            ${pkgs.sourceos-boot or defaultPackage}/bin/sourceos-boot rollback execute --execute || true
+            ${bootPkg}/bin/sourceos-boot rollback execute --execute || true
           ''}
           exit 2
         '';


### PR DESCRIPTION
## Summary

- **sops-nix**: added as flake input; `sops.nixosModules.sops` wired into `builder-aarch64`.
- **`hosts/builder-aarch64`**: `sops.secrets.katello-password` provides the secret file; `sourceos.syncd.katelloPasswordFile` points at it. `secrets.yaml.example` documents the plaintext structure; `hosts/**/secrets.yaml` is gitignored.
- **NixOS module bug fixes**:
  - `LoadCredential` + `EnvironmentFiles` combination was broken. Now uses `LoadCredential` → sets `KATELLO_PASSWORD_FILE` env var pointing at the credential path. `sourceos-syncd` reads it via `_resolve_password()`.
  - `pkgs.sourceos-boot or defaultPackage` was invalid Nix — replaced with `cfg.sourceosBoot.package` option.
  - `ExecStart` strings now use `lib.escapeShellArg` on user-supplied values.
- **`signingPublicKey` option**: sets `--signing-public-key` CLI flag and `SOURCEOS_SIGNING_PUBLIC_KEY` env. Leave empty until minisign key pair is generated on device.

## Test plan

- [ ] `nix flake check` passes (requires aarch64 builder or `--system aarch64-linux`)
- [ ] `nixos-rebuild build --flake .#builder-aarch64` succeeds on device
- [ ] `sops --decrypt hosts/builder-aarch64/secrets.yaml` resolves katello-password
- [ ] `systemctl cat sourceos-syncd` shows `KATELLO_PASSWORD_FILE=` in environment