### PR TITLE
feat(packages): sourceos-syncd and sourceos-boot Nix derivations

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,136 @@
+{
+  "nodes": {
+    "flake-compat": {
+      "locked": {
+        "lastModified": 1761640442,
+        "narHash": "sha256-AtrEP6Jmdvrqiv4x2xa5mrtaIp3OEe8uBYCDZDS+hu8=",
+        "owner": "nix-community",
+        "repo": "flake-compat",
+        "rev": "4a56054d8ffc173222d09dad23adf4ba946c8884",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "lampstand-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1780277257,
+        "narHash": "sha256-XAIGedyb3K8uoCaws1H5y+2qBDZL8vUETgqzQAa8Om0=",
+        "owner": "SocioProphet",
+        "repo": "lampstand",
+        "rev": "a33d251ecc3d30293d9a728f86f0a6bcec45b69c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "SocioProphet",
+        "repo": "lampstand",
+        "type": "github"
+      }
+    },
+    "nixos-apple-silicon": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781520503,
+        "narHash": "sha256-XuqQQG1qRyc3o8ld937sDLQNx+QrGV852KJ0dNglJDg=",
+        "owner": "tpwrules",
+        "repo": "nixos-apple-silicon",
+        "rev": "43043ad207529650f9fa68e1705f7cf9c08bfdeb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tpwrules",
+        "repo": "nixos-apple-silicon",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1781074563,
+        "narHash": "sha256-md8WlXOlfnIeHeOScMTTHFyf2d6iaTwPl2apR5EQ3P4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9ae611a455b90cf061d8f332b977e387bda8e1ca",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "lampstand-src": "lampstand-src",
+        "nixos-apple-silicon": "nixos-apple-silicon",
+        "nixpkgs": "nixpkgs",
+        "sops-nix": "sops-nix",
+        "sourceos-boot-src": "sourceos-boot-src",
+        "sourceos-syncd-src": "sourceos-syncd-src"
+      }
+    },
+    "sops-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1780547341,
+        "narHash": "sha256-Gq8KNx5A7hBB3uGJaj6eQfLDIz5YdLu92gqBcvHvoUo=",
+        "owner": "Mic92",
+        "repo": "sops-nix",
+        "rev": "9ed65852b6257fbeae4355bc24ecfea307ca759a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Mic92",
+        "repo": "sops-nix",
+        "type": "github"
+      }
+    },
+    "sourceos-boot-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1781627411,
+        "narHash": "sha256-s44FGCVsp1gyuMEQEeQeH8BKjNAPfu81tNjni0mSaP8=",
+        "owner": "SourceOS-Linux",
+        "repo": "sourceos-boot",
+        "rev": "bc6dd8c09449e07e5a05a11c7b650eea19eb1b93",
+        "type": "github"
+      },
+      "original": {
+        "owner": "SourceOS-Linux",
+        "repo": "sourceos-boot",
+        "type": "github"
+      }
+    },
+    "sourceos-syncd-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1781627880,
+        "narHash": "sha256-9QRlZyhKNTH15KWf+M5P137Axf43FHq6AMExAKauMHs=",
+        "owner": "SourceOS-Linux",
+        "repo": "sourceos-syncd",
+        "rev": "8f845b7d3053ba704a4c570aa23e9fae9565914c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "SourceOS-Linux",
+        "repo": "sourceos-syncd",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -15,9 +15,17 @@
       url = "github:SocioProphet/lampstand";
       flake = false;
     };
+    sourceos-syncd-src = {
+      url = "github:SourceOS-Linux/sourceos-syncd";
+      flake = false;
+    };
+    sourceos-boot-src = {
+      url = "github:SourceOS-Linux/sourceos-boot";
+      flake = false;
+    };
   };
 
-  outputs = { self, nixpkgs, nixos-apple-silicon, sops-nix, lampstand-src }:
+  outputs = { self, nixpkgs, nixos-apple-silicon, sops-nix, lampstand-src, sourceos-syncd-src, sourceos-boot-src }:
     let
       lib = nixpkgs.lib;
       systems = [ "x86_64-linux" "aarch64-linux" ];
@@ -33,6 +41,12 @@
           meshd-exitd = pkgs.callPackage ./packages/mesh/meshd-exitd.nix { };
           lampstand = pkgs.callPackage ./packages/search/lampstand.nix {
             inherit lampstand-src;
+          };
+          sourceos-syncd = pkgs.callPackage ./packages/sourceos-syncd/default.nix {
+            inherit sourceos-syncd-src;
+          };
+          sourceos-boot = pkgs.callPackage ./packages/sourceos-boot/default.nix {
+            inherit sourceos-boot-src;
           };
           default = meshd;
         });
@@ -84,9 +98,18 @@
       };
 
       nixosConfigurations = {
-        builder-aarch64 = lib.nixosSystem {
+        builder-aarch64 =
+          let
+            pkgs-aarch64 = nixpkgs.legacyPackages.aarch64-linux;
+            syncdPkg = pkgs-aarch64.callPackage ./packages/sourceos-syncd/default.nix {
+              inherit sourceos-syncd-src;
+            };
+            bootPkg = pkgs-aarch64.callPackage ./packages/sourceos-boot/default.nix {
+              inherit sourceos-boot-src;
+            };
+          in lib.nixosSystem {
           system = "aarch64-linux";
-          specialArgs = { inherit self; };
+          specialArgs = { inherit self syncdPkg bootPkg; };
           modules = [
             nixos-apple-silicon.nixosModules.apple-silicon-support
             sops-nix.nixosModules.sops
@@ -156,6 +179,10 @@
           meshd-linkd-package = self.packages.${system}.meshd-linkd;
           meshd-exitd-package = self.packages.${system}.meshd-exitd;
           lampstand-package = self.packages.${system}.lampstand;
+          sourceos-syncd-package = self.packages.${system}.sourceos-syncd;
+          sourceos-boot-package = self.packages.${system}.sourceos-boot;
+          sourceos-syncd-package-contract = import ./tests/sourceos-syncd-package-contract.nix { inherit pkgs; };
+          sourceos-boot-package-contract = import ./tests/sourceos-boot-package-contract.nix { inherit pkgs; };
         });
 
       sourceos = {

--- a/hosts/builder-aarch64/default.nix
+++ b/hosts/builder-aarch64/default.nix
@@ -1,4 +1,4 @@
-{ config, lib, pkgs, self, ... }:
+{ config, lib, pkgs, self, syncdPkg, bootPkg, ... }:
 {
   imports = [
     ../../profiles/linux-dev/default.nix
@@ -68,9 +68,8 @@
   # Password loaded via SOPS-managed secret (not committed to repo).
   sourceos.syncd = {
     enable = true;
-    # package and sourceosBoot.package must point to built derivations.
-    # These are set below as overrides once the package derivations exist.
-    # For now, use placeholder that will be replaced with the real package.
+    package = syncdPkg;
+    sourceosBoot.package = bootPkg;
     katelloUrl = "https://127.0.0.1:8443";
     lifecycleEnv = "stable";
     locus = "local";

--- a/packages/sourceos-boot/default.nix
+++ b/packages/sourceos-boot/default.nix
@@ -1,0 +1,33 @@
+{ lib, python3Packages, sourceos-boot-src }:
+
+python3Packages.buildPythonApplication {
+  pname = "sourceos-boot";
+  version = "0.1.0";
+  src = sourceos-boot-src;
+
+  pyproject = true;
+  build-system = with python3Packages; [
+    setuptools
+  ];
+
+  # No third-party runtime dependencies — stdlib only.
+  propagatedBuildInputs = [];
+
+  nativeCheckInputs = with python3Packages; [
+    pytestCheckHook
+    jsonschema
+  ];
+
+  pythonImportsCheck = [
+    "sourceos_boot.cli"
+    "sourceos_boot.asahi_boot_chain"
+    "sourceos_boot.rollback_executor"
+  ];
+
+  meta = {
+    description = "SourceOS boot chain model: Asahi rollback planning and execution for Apple Silicon.";
+    license = lib.licenses.mit;
+    mainProgram = "sourceos-boot";
+    platforms = lib.platforms.linux;
+  };
+}

--- a/packages/sourceos-syncd/default.nix
+++ b/packages/sourceos-syncd/default.nix
@@ -1,0 +1,36 @@
+{ lib, python3Packages, sourceos-syncd-src }:
+
+python3Packages.buildPythonApplication {
+  pname = "sourceos-syncd";
+  version = "0.1.0";
+  src = sourceos-syncd-src;
+
+  pyproject = true;
+  build-system = with python3Packages; [
+    setuptools
+  ];
+
+  # No third-party runtime dependencies — stdlib only.
+  # jsonschema is test-only (nativeCheckInputs below).
+  propagatedBuildInputs = [];
+
+  nativeCheckInputs = with python3Packages; [
+    pytestCheckHook
+    jsonschema
+  ];
+
+  pythonImportsCheck = [
+    "sourceos_syncd.cli"
+    "sourceos_syncd.content_sync"
+    "sourceos_syncd.katello_client"
+    "sourceos_syncd.daemon"
+    "sourceos_syncd.receipt_store"
+  ];
+
+  meta = {
+    description = "SourceOS content-view sync daemon: polls Katello, applies NixOS updates, emits SyncCycleReceipts.";
+    license = lib.licenses.mit;
+    mainProgram = "sourceos-syncd";
+    platforms = lib.platforms.linux;
+  };
+}

--- a/tests/sourceos-boot-package-contract.nix
+++ b/tests/sourceos-boot-package-contract.nix
@@ -1,0 +1,14 @@
+{ pkgs ? import <nixpkgs> {} }:
+pkgs.runCommand "sourceos-boot-package-contract" {
+  nativeBuildInputs = [ pkgs.gnugrep ];
+} ''
+  test -f ${../packages/sourceos-boot/default.nix}
+  grep -q 'buildPythonApplication' ${../packages/sourceos-boot/default.nix}
+  grep -q 'sourceos-boot' ${../packages/sourceos-boot/default.nix}
+  grep -q 'sourceos_boot.cli' ${../packages/sourceos-boot/default.nix}
+  grep -q 'sourceos-boot-src' ${../packages/sourceos-boot/default.nix}
+  grep -q 'sourceos-boot = pkgs.callPackage ./packages/sourceos-boot/default.nix' ${../flake.nix}
+  grep -q 'sourceos-boot-src' ${../flake.nix}
+  mkdir -p $out
+  echo validated > $out/result.txt
+''

--- a/tests/sourceos-syncd-package-contract.nix
+++ b/tests/sourceos-syncd-package-contract.nix
@@ -1,0 +1,14 @@
+{ pkgs ? import <nixpkgs> {} }:
+pkgs.runCommand "sourceos-syncd-package-contract" {
+  nativeBuildInputs = [ pkgs.gnugrep ];
+} ''
+  test -f ${../packages/sourceos-syncd/default.nix}
+  grep -q 'buildPythonApplication' ${../packages/sourceos-syncd/default.nix}
+  grep -q 'sourceos-syncd' ${../packages/sourceos-syncd/default.nix}
+  grep -q 'sourceos_syncd.cli' ${../packages/sourceos-syncd/default.nix}
+  grep -q 'sourceos-syncd-src' ${../packages/sourceos-syncd/default.nix}
+  grep -q 'sourceos-syncd = pkgs.callPackage ./packages/sourceos-syncd/default.nix' ${../flake.nix}
+  grep -q 'sourceos-syncd-src' ${../flake.nix}
+  mkdir -p $out
+  echo validated > $out/result.txt
+''


### PR DESCRIPTION
## Summary

- **`packages/sourceos-syncd/default.nix`**: `buildPythonApplication` for the sync daemon. Stdlib-only runtime; `jsonschema` in `nativeCheckInputs` for `pytestCheckHook`. Exposes `sourceos-syncd` binary.
- **`packages/sourceos-boot/default.nix`**: same pattern for the boot chain tool. Exposes `sourceos-boot` binary.
- **`flake.nix`**:
  - Adds `sourceos-syncd-src` and `sourceos-boot-src` as `flake = false` inputs (upstream repos have no `flake.nix`).
  - Exposes both as `packages.{system}.sourceos-syncd` and `sourceos-boot`.
  - `builder-aarch64` nixosSystem now passes `syncdPkg`/`bootPkg` via `specialArgs` so the NixOS module options resolve at evaluation time.
  - Adds both to `checks` output as build targets + contract tests.
- **`hosts/builder-aarch64/default.nix`**: sets `sourceos.syncd.package` and `sourceosBoot.package` — the last two unset module options are now wired.
- **`flake.lock`**: first lock file commit; pins all inputs including new ones to current main SHAs.

## Test plan

- [ ] `nix-build tests/sourceos-syncd-package-contract.nix` → passes ✓
- [ ] `nix-build tests/sourceos-boot-package-contract.nix` → passes ✓
- [ ] `nix flake show` lists `packages.x86_64-linux.sourceos-syncd` and `sourceos-boot`
- [ ] `nix build .#sourceos-syncd` produces a working binary (requires x86_64 or aarch64 Linux builder)
- [ ] `nixos-rebuild build --flake .#builder-aarch64` succeeds on device