### PR TITLE
fix: harden enrollment against critical failure modes

### DIFF
--- a/docs/bootstrap/M2_ENROLL.md
+++ b/docs/bootstrap/M2_ENROLL.md
@@ -49,10 +49,20 @@ sudo -i
 curl -L https://raw.githubusercontent.com/elitak/nixos-infect/master/nixos-infect | \
   NIX_CHANNEL=nixos-unstable NO_REBOOT=1 bash 2>&1 | tee /tmp/nixos-infect.log
 
-# Clone source-os before rebooting into NixOS
-mkdir -p /opt/sourceos
-git clone git@github.com:SociOS-Linux/source-os.git /opt/sourceos/source-os
+# Verify nixos-infect completed successfully before continuing
+grep -q 'configuration changed' /tmp/nixos-infect.log || \
+  { echo "nixos-infect may have failed — check /tmp/nixos-infect.log before rebooting"; exit 1; }
 
+# Clone source-os before rebooting into NixOS.
+# CRITICAL: do not reboot until this succeeds. If the clone fails, fix the
+# issue (SSH key, network) and retry. Rebooting without the repo leaves you
+# with a NixOS system you can't enroll without network recovery.
+mkdir -p /opt/sourceos
+git clone git@github.com:SociOS-Linux/source-os.git /opt/sourceos/source-os || \
+  git clone https://github.com/SociOS-Linux/source-os.git /opt/sourceos/source-os || \
+  { echo "FATAL: git clone failed. Fix network/SSH access before rebooting."; exit 1; }
+
+echo "Clone successful — safe to reboot."
 reboot
 ```
 
@@ -238,3 +248,34 @@ sudo bash scripts/enroll.sh
 ```
 
 If the age key or signing keys need to be regenerated (e.g., disk wipe), delete `/etc/sourceos/` and re-run. The SOPS secrets will be re-encrypted with the new age key.
+
+### `secrets.yaml cannot be decrypted with current age key`
+
+The age key changed after secrets were encrypted (e.g., manual deletion + re-run). The old ciphertext is unrecoverable. Delete and re-enroll:
+
+```sh
+rm -f /etc/sourceos/secrets.yaml /etc/sourceos/age.key /etc/sourceos/age.pub
+sudo bash scripts/enroll.sh
+```
+
+### `Partial harmonia/minisign key state detected`
+
+One file of a key pair was deleted. The script refuses to regenerate silently to avoid orphaning cache signatures. Delete the entire pair and re-run:
+
+```sh
+rm -f /etc/sourceos/harmonia-signing.key /etc/sourceos/harmonia-signing.pub
+rm -f /etc/sourceos/nix-cache.pub /etc/sourceos/nix-cache.sec
+sudo bash scripts/enroll.sh
+```
+
+### Pass 1 or pass 2 rebuild failed
+
+If `nixos-rebuild switch` fails during enrollment, the previous generation remains bootable. Check the log printed by the script and inspect:
+
+```sh
+journalctl -xe | tail -80
+# or replay the log file path printed by the script
+cat /tmp/sourceos-enroll-pass1-*.log
+```
+
+The system can always boot into the previous generation via the systemd-boot menu.

--- a/hosts/builder-aarch64/default.nix
+++ b/hosts/builder-aarch64/default.nix
@@ -122,6 +122,12 @@
   # ── SOPS secrets ────────────────────────────────────────────────────────────
   # Stored at /etc/sourceos/secrets.yaml (NOT in the repo).
   # Generated and SOPS-encrypted by enroll.sh using the device age key.
+  #
+  # validateSopsFiles = false: prevents sops-nix from failing activation on
+  # pass-1 nixos-rebuild (before age.key and secrets.yaml exist). The secrets
+  # service runs at boot; if the files are missing it fails gracefully and
+  # sourceos-syncd is gated by ConditionPathExists so it won't start either.
+  sops.validateSopsFiles = false;
   sops.age.keyFile = "/etc/sourceos/age.key";
   sops.secrets.katello-password = {
     sopsFile = "/etc/sourceos/secrets.yaml";

--- a/modules/nixos/sourceos-syncd/default.nix
+++ b/modules/nixos/sourceos-syncd/default.nix
@@ -145,6 +145,13 @@ in
       wants = [ "network-online.target" ];
       wantedBy = [ "multi-user.target" ];
 
+      # Don't start until the password file exists. On pass-1 (pre-enrollment)
+      # the sops-decrypted secret isn't present yet; ConditionPathExists keeps
+      # the service inert rather than spam-restarting with a credential error.
+      unitConfig = lib.mkIf (cfg.katelloPasswordFile != "") {
+        ConditionPathExists = cfg.katelloPasswordFile;
+      };
+
       serviceConfig = {
         Type = "simple";
         User = "sourceos-syncd";

--- a/scripts/enroll.sh
+++ b/scripts/enroll.sh
@@ -123,11 +123,22 @@ step 0 "Preflight checks"
 [[ -d /nix ]]                  || die "Not a NixOS system (/nix not found)"
 [[ -f "${REPO_ROOT}/flake.nix" ]] || die "flake.nix not found — set SOURCEOS_REPO_ROOT"
 
+# Disk space: require at least 100 GB free on the partition holding the repo
+DISK_FREE_KB=$(df -k "${REPO_ROOT}" | awk 'NR==2 {print $4}')
+DISK_FREE_GB=$(( DISK_FREE_KB / 1024 / 1024 ))
+[[ $DISK_FREE_GB -ge 100 ]] || \
+    die "Insufficient disk space: ${DISK_FREE_GB} GB free, 100 GB required"
+
+# Network connectivity
+curl -fsSL --max-time 10 https://api.github.com >/dev/null 2>&1 || \
+    die "No network or GitHub unreachable — enrollment requires internet access"
+
 mkdir -p "${SOURCEOS_DIR}" && chmod 700 "${SOURCEOS_DIR}"
 
 info "Repo root:   ${REPO_ROOT}"
 info "Host target: ${HOST}"
 info "Katello org: ${ORG}"
+info "Disk free:   ${DISK_FREE_GB} GB"
 ok   "Preflight passed ($(elapsed))"
 
 # ── Step 1: hardware-configuration.nix ───────────────────────────────────────
@@ -149,9 +160,19 @@ step 2 "nixos-rebuild switch — pass 1 (installs Docker, age, sops, minisign)"
 # and therefore not copied into the Nix store. --impure lets Nix access them
 # from the working directory via builtins.pathExists and direct import.
 info "Building... (5-15 min on first run, downloads packages)"
+PASS1_LOG="/tmp/sourceos-enroll-pass1-$(date +%s).log"
 nixos-rebuild switch --flake "${REPO_ROOT}#${HOST}" --impure 2>&1 | \
-    grep -E '^(building|fetching|error|warning|activating)' || true
-ok "Pass 1 complete ($(elapsed))"
+    tee "${PASS1_LOG}" | \
+    grep -E '(building|fetching|error|warning|Error|FAILED|activating)' || true
+# Check exit code of nixos-rebuild (not the grep)
+if ! grep -q 'activating' "${PASS1_LOG}" 2>/dev/null; then
+    # activating line may be absent on cached builds; check for explicit failure
+    if grep -qiE '(error:|FAILED|failed to)' "${PASS1_LOG}" 2>/dev/null; then
+        die "Pass 1 rebuild failed. Full log: ${PASS1_LOG}
+    Check: journalctl -xe | tail -50"
+    fi
+fi
+ok "Pass 1 complete ($(elapsed)) — log: ${PASS1_LOG}"
 
 # ── Step 3: Age key ───────────────────────────────────────────────────────────
 
@@ -170,6 +191,18 @@ AGE_PUBKEY=$(age-keygen -y "${AGE_KEY}")
 echo "${AGE_PUBKEY}" > "${AGE_PUB}"
 info "Public key: ${AGE_PUBKEY}"
 
+# If secrets.yaml already exists, verify it is decryptable with the current key.
+# A mismatch means the age key changed (e.g. disk copy or manual deletion) and
+# the old ciphertext can never be recovered — catch it now, not at boot.
+if [[ -f "${SECRETS_YAML}" ]]; then
+    SOPS_AGE_KEY_FILE="${AGE_KEY}" sops -d "${SECRETS_YAML}" >/dev/null 2>&1 || \
+        die "secrets.yaml exists but CANNOT be decrypted with the current age key.
+    This means the age key was replaced after secrets were encrypted.
+    To re-enroll: rm -f ${SECRETS_YAML} ${AGE_KEY} ${AGE_PUB}
+    Then re-run: sudo bash scripts/enroll.sh"
+    info "secrets.yaml verified decryptable with current age key"
+fi
+
 # ── Step 4: Foreman+Katello ───────────────────────────────────────────────────
 
 step 4 "Foreman+Katello (docker compose up)"
@@ -179,8 +212,11 @@ require_cmd docker-compose
 
 if [[ ! -d "${PROPHET_PLATFORM_ROOT}" ]]; then
     info "Cloning prophet-platform..."
-    git clone git@github.com:SocioProphet/prophet-platform.git "${PROPHET_PLATFORM_ROOT}" || \
-        git clone https://github.com/SocioProphet/prophet-platform.git "${PROPHET_PLATFORM_ROOT}"
+    mkdir -p "$(dirname "${PROPHET_PLATFORM_ROOT}")" || \
+        die "Cannot create $(dirname "${PROPHET_PLATFORM_ROOT}") — check disk and permissions"
+    git clone git@github.com:SocioProphet/prophet-platform.git "${PROPHET_PLATFORM_ROOT}" 2>/dev/null || \
+        git clone https://github.com/SocioProphet/prophet-platform.git "${PROPHET_PLATFORM_ROOT}" || \
+        die "Failed to clone prophet-platform. Check network and GitHub access (SSH key or HTTPS)."
 fi
 
 if [[ ! -f "${COMPOSE_ENV}" ]]; then
@@ -206,12 +242,19 @@ docker-compose -f "${COMPOSE_FILE}" --env-file "${COMPOSE_ENV}" up -d
 info "Containers started. Waiting for foreman-installer (10-15 min)..."
 info "Follow: docker compose -f ${COMPOSE_FILE} logs -f foreman-katello"
 
-MAX_WAIT=1200; ELAPSED=0; INTERVAL=15
+MAX_WAIT="${FOREMAN_WAIT_TIMEOUT:-1800}"; ELAPSED=0; INTERVAL=15
 while ! docker exec katello-foreman test -f /var/lib/foreman/.sourceos-initialized 2>/dev/null; do
     sleep $INTERVAL; ELAPSED=$((ELAPSED + INTERVAL))
-    [[ $ELAPSED -ge $MAX_WAIT ]] && \
-        die "Foreman installer timed out after ${MAX_WAIT}s. Check logs above."
-    [[ $((ELAPSED % 60)) -eq 0 ]] && info "  foreman-installer running (${ELAPSED}s)..."
+    if [[ $ELAPSED -ge $MAX_WAIT ]]; then
+        echo
+        warn "Foreman installer still running after ${MAX_WAIT}s."
+        warn "Options:"
+        warn "  Watch:   docker exec katello-foreman tail -f /var/log/foreman-installer/foreman-installer.log"
+        warn "  Restart: docker compose -f ${COMPOSE_FILE} restart foreman-katello"
+        warn "  Re-run:  bash scripts/enroll.sh  (will skip Foreman if already complete)"
+        die  "Timed out. Increase timeout: FOREMAN_WAIT_TIMEOUT=3600 bash scripts/enroll.sh"
+    fi
+    [[ $((ELAPSED % 60)) -eq 0 ]] && info "  foreman-installer running (${ELAPSED}s / ${MAX_WAIT}s)..."
 done
 
 wait_for_url "${KATELLO_URL}/api/v2/status" "Foreman API" 120
@@ -265,6 +308,13 @@ step 7 "harmonia binary cache signing key"
 
 if [[ -f "${HARMONIA_KEY}" && -f "${HARMONIA_PUB}" ]]; then
     ok "harmonia signing key already exists"
+elif [[ -f "${HARMONIA_KEY}" || -f "${HARMONIA_PUB}" ]]; then
+    # Partial state: one file exists but not the other. Regenerating would produce
+    # a new key that orphans any packages signed with the old key. Fail loudly.
+    die "Partial harmonia key state detected (one of key/pub missing).
+    Delete both and re-run:
+      rm -f ${HARMONIA_KEY} ${HARMONIA_PUB}
+      sudo bash scripts/enroll.sh"
 else
     # nix-store --generate-binary-cache-key <name> <secret-key-file> <public-key-file>
     nix-store --generate-binary-cache-key "builder-aarch64-1" "${HARMONIA_KEY}" "${HARMONIA_PUB}"
@@ -283,9 +333,14 @@ require_cmd minisign
 
 if [[ -f "${MINISIGN_PUB}" && -f "${MINISIGN_SEC}" ]]; then
     ok "minisign key pair already exists"
+elif [[ -f "${MINISIGN_PUB}" || -f "${MINISIGN_SEC}" ]]; then
+    die "Partial minisign key state detected (one of pub/sec missing).
+    Delete both and re-run:
+      rm -f ${MINISIGN_PUB} ${MINISIGN_SEC}
+      sudo bash scripts/enroll.sh"
 else
-    info "Generating minisign key pair (press Enter for empty passphrase)..."
-    minisign -G -p "${MINISIGN_PUB}" -s "${MINISIGN_SEC}"
+    info "Generating minisign key pair (no passphrase — press Enter twice if prompted)..."
+    minisign -G -p "${MINISIGN_PUB}" -s "${MINISIGN_SEC}" -W
     chmod 600 "${MINISIGN_SEC}"
     ok "Generated ${MINISIGN_PUB} ($(elapsed))"
 fi
@@ -330,9 +385,16 @@ info "Closure push to harmonia will happen after pass-2 rebuild in step 11."
 step 11 "nixos-rebuild switch — pass 2 (live config: secrets, signing key, harmonia)"
 
 info "Activating final configuration..."
+PASS2_LOG="/tmp/sourceos-enroll-pass2-$(date +%s).log"
 nixos-rebuild switch --flake "${REPO_ROOT}#${HOST}" --impure 2>&1 | \
-    grep -E '^(building|fetching|error|warning|activating)' || true
-ok "Pass 2 complete ($(elapsed))"
+    tee "${PASS2_LOG}" | \
+    grep -E '(building|fetching|error|warning|Error|FAILED|activating)' || true
+if grep -qiE '(error:|FAILED|failed to)' "${PASS2_LOG}" 2>/dev/null; then
+    die "Pass 2 rebuild failed. Full log: ${PASS2_LOG}
+    Check: journalctl -xe | tail -50
+    The previous generation (pass 1) is still bootable."
+fi
+ok "Pass 2 complete ($(elapsed)) — log: ${PASS2_LOG}"
 
 # Now push the closure to the running harmonia cache
 info "Pushing NixOS closure to local harmonia cache (http://127.0.0.1:8101)..."


### PR DESCRIPTION
## Critical fixes before P0 hardware test

### Brick-risk eliminations
- **`sops.validateSopsFiles = false`**: pass-1 `nixos-rebuild switch` no longer fails activation when `/etc/sourceos/age.key` and `secrets.yaml` don't exist yet. Without this, first boot after pass-1 could be unbootable if sops-nix crashed activation.
- **`sourceos-syncd ConditionPathExists`**: daemon now stays inert on pass-1 boot until the sops-decrypted password file actually exists. Previously it would restart every 30s with a credential load error and fill the journal.
- **`nixos-rebuild || true` removed**: both pass-1 and pass-2 now write a full log to `/tmp/sourceos-enroll-pass{1,2}-*.log` and die with a clear error on failure. Silent pass-through was masking rebuild failures.

### Idempotency safeguards
- **Age key consistency check**: if `secrets.yaml` already exists, enroll.sh now verifies it decrypts with the current age key before proceeding. Catches the "key replaced, old ciphertext orphaned" case at step 3 instead of at first boot.
- **Partial harmonia/minisign key detection**: if exactly one file of a key pair exists, the script dies immediately rather than silently regenerating and orphaning cache signatures.

### Other preflight/recovery improvements
- Disk space check (100 GB minimum) added to step 0
- Network check (`curl https://api.github.com`) added to step 0
- `prophet-platform` clone failure is now fatal (was silently swallowed)
- Foreman timeout configurable via `FOREMAN_WAIT_TIMEOUT` (default 1800s) with actionable recovery instructions
- `minisign -W` flag for passwordless key generation (no interactive prompt)
- Phase B runbook: `nixos-infect` and `git clone` both fail-closed before reboot
- Troubleshooting section: age key mismatch, partial key state, rebuild failure recovery