### PR TITLE
fix: fourth audit — nix build log, signing key validation, idempotent publish, hw-config cleanup

### DIFF
--- a/scripts/enroll.sh
+++ b/scripts/enroll.sh
@@ -145,6 +145,8 @@ ok   "Preflight passed ($(elapsed))"
 
 step 1 "Hardware configuration"
 
+rm -f "${HW_CONFIG}.tmp"  # clean up any stale temp from a previous interrupted run
+
 if [[ -f "${HW_CONFIG}" ]]; then
     ok "hardware-configuration.nix already present"
 else
@@ -354,6 +356,9 @@ else
 fi
 
 SIGNING_PUBKEY=$(grep -v '^untrusted comment' "${MINISIGN_PUB}" | head -1)
+[[ -n "${SIGNING_PUBKEY}" ]] || \
+    die "minisign public key file is empty or malformed: ${MINISIGN_PUB}
+    Delete and re-run: rm -f ${MINISIGN_PUB} ${MINISIGN_SEC} && sudo bash scripts/enroll.sh"
 info "Signing public key: ${SIGNING_PUBKEY}"
 
 # Write nix-cache-info and sign it. nginx serves the .minisig file alongside
@@ -380,13 +385,14 @@ ok "enroll.nix written — no Nix file patching needed ($(elapsed))"
 step 10 "Build NixOS closure + push to harmonia cache"
 
 info "Building builder-aarch64 system closure..."
+BUILD_LOG="/tmp/sourceos-enroll-nix-build-$(date +%s).log"
 CLOSURE=$(nix build "${REPO_ROOT}#nixosConfigurations.${HOST}.config.system.build.toplevel" \
-    --no-link --print-out-paths 2>/dev/null)
-# nix build returns empty stdout on failure (errors go to stderr). Verify both that
-# CLOSURE is non-empty and that the path actually exists in the Nix store.
+    --no-link --print-out-paths 2>"${BUILD_LOG}")
+# nix build emits errors only to stderr (captured to BUILD_LOG above).
+# Verify stdout produced a non-empty, existing store path.
 [[ -n "${CLOSURE}" && -e "${CLOSURE}" ]] || \
-    die "nix build failed — retry with:
-    nix build ${REPO_ROOT}#nixosConfigurations.${HOST}.config.system.build.toplevel --no-link --show-trace"
+    die "nix build failed. Build log: ${BUILD_LOG}
+    For full trace: nix build ${REPO_ROOT}#nixosConfigurations.${HOST}.config.system.build.toplevel --no-link --show-trace"
 ok "Built: ${CLOSURE}"
 
 # Harmonia must be running before we can push (it starts after pass-2 rebuild).

--- a/scripts/katello-sourceos-setup.sh
+++ b/scripts/katello-sourceos-setup.sh
@@ -78,13 +78,26 @@ $HAMMER content-view add-repository --organization "${ORG}" \
     --repository "sourceos-closures-aarch64" \
     2>/dev/null || echo "  sourceos-closures-aarch64 already in view"
 
-# Publish version 1.0 to Library
-echo "--- publishing content view (this may take a minute)"
-$HAMMER content-view publish --organization "${ORG}" \
-    --name "sourceos-builder-aarch64" \
-    --description "Initial publish — dev channel bootstrap"
+# Publish version 1.0 to Library — skip if any version already exists.
+# Re-running katello-sourceos-setup.sh (e.g. during enroll.sh retry) must not
+# create a new CV version: publishing is slow (1-2 min) and the extra versions
+# are noise that complicates CV_VERSION selection in subsequent steps.
+echo "--- checking content view publish state"
+EXISTING_CV_VERSIONS=$($HAMMER --output json content-view version list \
+    --organization "${ORG}" \
+    --content-view "sourceos-builder-aarch64" 2>/dev/null | \
+    python3 -c "import json,sys; print(len(json.load(sys.stdin)))" 2>/dev/null || echo "0")
 
-# Promote to dev lifecycle environment
+if [[ "${EXISTING_CV_VERSIONS}" -eq 0 ]]; then
+    echo "--- publishing content view (this may take a minute)"
+    $HAMMER content-view publish --organization "${ORG}" \
+        --name "sourceos-builder-aarch64" \
+        --description "Initial publish — dev channel bootstrap"
+else
+    echo "  content view already has ${EXISTING_CV_VERSIONS} version(s) — skipping publish"
+fi
+
+# Promote to dev lifecycle environment (idempotent — hammer returns 0 if already promoted)
 echo "--- promoting to dev"
 CV_VERSION=$($HAMMER --output json content-view version list \
     --organization "${ORG}" \


### PR DESCRIPTION
## Fourth audit findings

### H1 — Step 10: `nix build 2>/dev/null` hides all build errors

When `nix build` fails, the die message told the operator to re-run with `--show-trace` — but they had no idea what failed because stderr was suppressed. Replaced `2>/dev/null` with `2>"${BUILD_LOG}"`, where `BUILD_LOG` is a timestamped path in `/tmp`. The die message now includes the log path so the operator can read the error immediately without re-running.

### H2 — Step 8: Empty/corrupt minisign public key not caught before writing enroll.nix

`SIGNING_PUBKEY=$(grep -v '^untrusted comment' "${MINISIGN_PUB}" | head -1)` returns an empty string if the pub file exists but is malformed (e.g. interrupted write from a previous run). Without validation, `write_enroll_nix ""` silently writes `signingPublicKey = ""` to enroll.nix. Pass-2 nixos-rebuild then fails with a Nix type error that has no obvious connection to the signing key. Added `[[ -n "${SIGNING_PUBKEY}" ]]` guard with a clear remediation instruction.

### H3 — `katello-sourceos-setup.sh`: `content-view publish` not idempotent

Every call to `katello-sourceos-setup.sh` (invoked unconditionally by enroll.sh step 5) published a new content view version regardless of whether any version already existed. Publishing is a slow operation (1–2 min Katello sync) and creates spurious versions (v1.0, v2.0, v3.0...) that clutter the CV history. The CV_VERSION selection at the end (`sorted by ID, take last`) still worked correctly, but the extra round-trip on every re-run is wasteful and incorrect.

Fix: check `content-view version list` count before publishing; skip if any version already exists.

### M1 — Step 1: Stale `hardware-configuration.nix.tmp` from previous interrupted runs

The atomic write pattern (`> .tmp` → `mv .tmp final`) leaves a `.tmp` on disk if step 1 is interrupted after `nixos-generate-config` but before `mv`. On re-run, the `.tmp` is silently overwritten anyway (the idempotent check looks for `HW_CONFIG`, not `.tmp`), but the stale file is confusing. Added `rm -f "${HW_CONFIG}.tmp"` at the top of step 1.