### PR TITLE
desktop-gnome: ship BearBrowser as the default browser

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -43,6 +43,7 @@
           meshd = pkgs.callPackage ./packages/mesh/meshd.nix { };
           meshd-linkd = pkgs.callPackage ./packages/mesh/meshd-linkd.nix { };
           meshd-exitd = pkgs.callPackage ./packages/mesh/meshd-exitd.nix { };
+          bearbrowser = pkgs.callPackage ./packages/browser/bearbrowser.nix { };
           lampstand = pkgs.callPackage ./packages/search/lampstand.nix {
             inherit lampstand-src;
           };

--- a/packages/browser/bearbrowser.nix
+++ b/packages/browser/bearbrowser.nix
@@ -1,0 +1,120 @@
+# BearBrowser — SourceOS privacy / anti-fingerprinting browser.
+#
+# Packages the prebuilt Linux Gecko build (compiled with the BearBrowser engine
+# anti-fingerprint patches: canvas text-metric quantization + audio farble in
+# libxul) from the BearBrowser GitHub release. This is a prebuilt-binary wrapper
+# (firefox-bin style) — autoPatchelf + the Gecko runtime libs + a desktop entry.
+#
+# NOTE: built from the v0.1.0-alpha "human-secure" Linux artifact. When a new
+# release is cut, bump `version` + `src.url` + `src.hash`.
+{ lib
+, stdenv
+, fetchurl
+, autoPatchelfHook
+, makeWrapper
+, wrapGAppsHook3
+, gtk3
+, glib
+, dbus-glib
+, libXt
+, alsa-lib
+, libX11
+, libXcursor
+, libXdamage
+, libXrandr
+, libXcomposite
+, libXext
+, libXfixes
+, libXrender
+, libXtst
+, libXScrnSaver
+, nspr
+, nss
+, pango
+, atk
+, cairo
+, gdk-pixbuf
+, freetype
+, fontconfig
+, libxcb
+, mesa
+, pciutils
+, ffmpeg
+, libnotify
+, gnome2 ? null
+}:
+
+stdenv.mkDerivation rec {
+  pname = "bearbrowser";
+  version = "0.1.0-alpha";
+
+  src = fetchurl {
+    url = "https://github.com/SourceOS-Linux/BearBrowser/releases/download/v${version}/bearbrowser-${version}-linux-x86_64.tar.gz";
+    hash = "sha256-K17S8uORD1RDL7OLPyU2LkxcXgo5fTBGIRJ+Nd/gNRA=";
+  };
+
+  nativeBuildInputs = [ autoPatchelfHook makeWrapper wrapGAppsHook3 ];
+
+  # Gecko runtime libraries (autoPatchelf resolves the binary's NEEDED libs here).
+  buildInputs = [
+    stdenv.cc.cc        # libstdc++ / libgcc_s
+    gtk3 glib dbus-glib libXt alsa-lib
+    libX11 libXcursor libXdamage libXrandr libXcomposite libXext libXfixes
+    libXrender libXtst libXScrnSaver
+    nspr nss pango atk cairo gdk-pixbuf freetype fontconfig libxcb mesa
+    pciutils ffmpeg libnotify
+  ];
+
+  # The release tarball is a dist/bin tree rooted at ./bin/.
+  sourceRoot = ".";
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    # Stage the Gecko dist under libexec, expose a wrapped launcher on PATH.
+    mkdir -p "$out/libexec/bearbrowser" "$out/bin" "$out/share/applications" "$out/share/pixmaps"
+    cp -r bin/* "$out/libexec/bearbrowser/"
+
+    # The executable is named "bearbrowser" (--with-app-name=bearbrowser).
+    makeWrapper "$out/libexec/bearbrowser/bearbrowser" "$out/bin/bearbrowser" \
+      --prefix LD_LIBRARY_PATH : "$out/libexec/bearbrowser" \
+      --set MOZ_LEGACY_PROFILES 1 \
+      --set MOZ_ALLOW_DOWNGRADE 1
+
+    # Icon (fall back silently if the dist layout differs).
+    if [ -f "$out/libexec/bearbrowser/browser/chrome/icons/default/default128.png" ]; then
+      cp "$out/libexec/bearbrowser/browser/chrome/icons/default/default128.png" \
+         "$out/share/pixmaps/bearbrowser.png" || true
+    fi
+
+    cat > "$out/share/applications/bearbrowser.desktop" <<EOF
+    [Desktop Entry]
+    Version=1.0
+    Type=Application
+    Name=BearBrowser
+    GenericName=Web Browser
+    Comment=SourceOS privacy / anti-fingerprinting browser
+    Exec=$out/bin/bearbrowser %U
+    Icon=bearbrowser
+    Terminal=false
+    Categories=Network;WebBrowser;
+    MimeType=text/html;text/xml;application/xhtml+xml;x-scheme-handler/http;x-scheme-handler/https;
+    StartupNotify=true
+    StartupWMClass=bearbrowser
+    EOF
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "SourceOS privacy / anti-fingerprinting browser (Gecko + engine anti-fp patches)";
+    homepage = "https://github.com/SourceOS-Linux/BearBrowser";
+    license = lib.licenses.mpl20;   # LibreWolf/Firefox base — MPL-2.0
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    mainProgram = "bearbrowser";
+  };
+}

--- a/profiles/desktop-gnome/default.nix
+++ b/profiles/desktop-gnome/default.nix
@@ -4,14 +4,16 @@
 #
 # The imperative GNOME "polish" layer (profiles/linux-dev/workstation-v0) can be
 # applied on top after first boot via its apply.sh; it is not required to boot.
-{ self, lib, pkgs, ... }:
+{ lib, pkgs, ... }:
 let
   # BearBrowser — the SourceOS default browser (Gecko + anti-fingerprint engine
-  # patches), packaged in packages/browser/bearbrowser.nix. The prebuilt release
-  # artifact is x86_64-only for now, so fall back to Firefox on aarch64 until an
-  # aarch64 BearBrowser build exists.
+  # patches), packaged in packages/browser/bearbrowser.nix. Built via callPackage
+  # so this works in any module-eval context (the boot VM tests don't pass `self`).
+  # The prebuilt release artifact is x86_64-only for now, so fall back to Firefox
+  # on aarch64 until an aarch64 BearBrowser build exists.
   isX86 = pkgs.stdenv.hostPlatform.system == "x86_64-linux";
-  browser = if isX86 then self.packages.x86_64-linux.bearbrowser else pkgs.firefox;
+  bearbrowser = pkgs.callPackage ../../packages/browser/bearbrowser.nix { };
+  browser = if isX86 then bearbrowser else pkgs.firefox;
   browserDesktop = if isX86 then "bearbrowser.desktop" else "firefox.desktop";
 in
 {

--- a/profiles/desktop-gnome/default.nix
+++ b/profiles/desktop-gnome/default.nix
@@ -4,7 +4,16 @@
 #
 # The imperative GNOME "polish" layer (profiles/linux-dev/workstation-v0) can be
 # applied on top after first boot via its apply.sh; it is not required to boot.
-{ lib, pkgs, ... }:
+{ self, lib, pkgs, ... }:
+let
+  # BearBrowser — the SourceOS default browser (Gecko + anti-fingerprint engine
+  # patches), packaged in packages/browser/bearbrowser.nix. The prebuilt release
+  # artifact is x86_64-only for now, so fall back to Firefox on aarch64 until an
+  # aarch64 BearBrowser build exists.
+  isX86 = pkgs.stdenv.hostPlatform.system == "x86_64-linux";
+  browser = if isX86 then self.packages.x86_64-linux.bearbrowser else pkgs.firefox;
+  browserDesktop = if isX86 then "bearbrowser.desktop" else "firefox.desktop";
+in
 {
   imports = [ ../base/default.nix ];
 
@@ -26,6 +35,17 @@
 
   users.users.sourceos.extraGroups = [ "video" "audio" ];
 
-  environment.systemPackages = with pkgs; [ firefox gnome-tweaks ];
+  # BearBrowser replaces Firefox as the shipped browser on the SourceOS desktop
+  # (x86_64; Firefox fallback on aarch64 until an aarch64 build exists).
+  environment.systemPackages = [ browser ] ++ (with pkgs; [ gnome-tweaks ]);
   environment.gnome.excludePackages = with pkgs; [ gnome-tour epiphany geary ];
+
+  # Make it the default browser (http/https + html).
+  xdg.mime.defaultApplications = {
+    "text/html" = browserDesktop;
+    "x-scheme-handler/http" = browserDesktop;
+    "x-scheme-handler/https" = browserDesktop;
+    "x-scheme-handler/about" = browserDesktop;
+    "x-scheme-handler/unknown" = browserDesktop;
+  };
 }

--- a/profiles/linux-dev/workstation-v0/gnome/mac-defaults.sh
+++ b/profiles/linux-dev/workstation-v0/gnome/mac-defaults.sh
@@ -66,7 +66,7 @@ main(){
   mkdir -p "$HOME/Pictures/Screenshots"
 
   # Favorites / dock seed (best-effort)
-  set_key org.gnome.shell favorite-apps "['org.gnome.Nautilus.desktop', 'org.gnome.Terminal.desktop', 'firefox.desktop', 'org.gnome.Settings.desktop']"
+  set_key org.gnome.shell favorite-apps "['org.gnome.Nautilus.desktop', 'org.gnome.Terminal.desktop', 'bearbrowser.desktop', 'org.gnome.Settings.desktop']"
 
   # Preserve palette hotkey in custom0, then add Finder/Terminal/screenshot bindings.
   local base="/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/"


### PR DESCRIPTION
Integrates BearBrowser into the SourceOS workstation — it was **entirely absent** (the desktop shipped upstream Firefox; `source-os` had zero BearBrowser references).

## What this adds
- `packages/browser/bearbrowser.nix` — prebuilt-binary wrapper for the BearBrowser Gecko build **with the anti-fingerprint engine patches** (canvas text-metric quantize + audio farble compiled into libxul), pulled from the [v0.1.0-alpha release](https://github.com/SourceOS-Linux/BearBrowser/releases/tag/v0.1.0-alpha). autoPatchelf + Gecko runtime libs + a `.desktop` entry.
- `flake.nix` — registers `packages.<system>.bearbrowser`.
- `profiles/desktop-gnome` — replaces Firefox with BearBrowser + sets it as the default browser (xdg mime). **x86_64 only**; aarch64 falls back to Firefox until an aarch64 build exists.

This realizes the **workstation-contract** intent (PackageManifest + launcher + desktop profile) from `SourceOS-Linux/sourceos-spec` in Nix terms.

## Verification status
- ✅ All three files parse-check clean (`nix-instantiate --parse`).
- ⚠️ **NOT yet `nix build`-verified** — needs an x86_64-linux builder (couldn't run here). `autoPatchelfHook` will surface any additional NEEDED runtime libs to add to `buildInputs` on first real build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)