### PR TITLE
copilot/update-copilot-instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,3 +1,13 @@
+## Executor policy
+
+**Copilot is the primary executor** for bounded issue-first PR work in this repository.
+
+- The issue body is the complete source of truth for every task. Do not rely on later comments; Copilot may not see them after assignment.
+- Delivery is confirmed only when GitHub shows a PR, branch, commit, or merge. Issue comments alone — including Codex comments — are **not** delivery artifacts.
+- Codex may be used for review, cross-repo analysis, or as a backup executor, but never as the default executor.
+
+---
+
 Use the GitHub issue body as the source of truth.
 
 Before editing:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,15 @@
 
 Work issue-first.
 
+## Executor policy
+
+**Copilot is the primary executor** for bounded issue-first PR work in this repository.
+
+- Assign issues to Copilot to produce verifiable GitHub work artifacts (PR, branch, commit, or merge).
+- Codex may be used as a reviewer, cross-repo analyst, or backup executor — it is not the default executor.
+- Codex issue comments alone are **not** delivery artifacts. Delivery is only confirmed when GitHub shows a PR, branch, commit, or merge.
+- The issue body must contain the full task specification because Copilot may not see later issue comments after assignment.
+
 Rules:
 
 - One repo, one issue, one PR.


### PR DESCRIPTION
Content-capture sweep: branch is 2 ahead / 127 behind main. Part of the multi-repo integration audit (2026-07-04). Cherry-pick/merge triage to follow.